### PR TITLE
refactor(tasks): remove duplicate auth helpers

### DIFF
--- a/src/app/api/v1/tasks/route.ts
+++ b/src/app/api/v1/tasks/route.ts
@@ -1,43 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import prisma from '@/lib/prisma'
-
-// Helper function to check if user has membership in a list
-async function checkListMembership(userId: string, listId: string): Promise<boolean> {
-  const list = await prisma.list.findUnique({
-    where: { id: listId },
-    select: {
-      users: true
-    }
-  })
-
-  if (!list) {
-    return false
-  }
-
-  return list.users.some(
-    (userRef: any) =>
-      userRef.userId === userId &&
-      ['OWNER', 'MANAGER', 'COLLABORATOR'].includes(userRef.role)
-  )
-}
-
-// Helper function to get user's role in a list
-async function getUserListRole(userId: string, listId: string): Promise<string | null> {
-  const list = await prisma.list.findUnique({
-    where: { id: listId },
-    select: {
-      users: true
-    }
-  })
-
-  if (!list) {
-    return null
-  }
-
-  const userRef = list.users.find((ref: any) => ref.userId === userId)
-  return userRef?.role || null
-}
+import { getUserListRole } from '@/lib/services/auth'
 
 export async function GET(request: NextRequest) {
   try {


### PR DESCRIPTION
Remove duplicate checkListMembership and getUserListRole functions from tasks route and import from centralized @/lib/services/auth instead. This eliminates code duplication and ensures consistent authorization logic across the application.

- Removed 36 lines of duplicate helper code
- Import getUserListRole from @/lib/services/auth
- Maintains same functionality with cleaner, DRY code

PLEASE REVIEW YOUR OWN PR BEFORE OPENING/UN-DRAFTING IT

# [Ticket Title]

[ticket description]

## Screenshots/Videocasts/Preview Links

## Have you?

- [ ] Reviewed your own PR?
- [ ] Tested your own feature/fix meets Acceptance Criteria?
- [ ] Made sure it passes all checks? (lint, build, integrations, scripts, etc)?
- [ ] Added screenshots? (if relevant)
- [ ] Added unit tests? (if necessary)
- [ ] Added documentation? (if necessary)

If so, THANKS! You can pop a beer/soda.

Please open your PR and ping your colleagues to review it on #web-devs channel.

Also, make sure to remind them on a daily basis during stand-up.
