### PR TITLE
Fix assistant controls on mobile

### DIFF
--- a/src/components/agentChat.tsx
+++ b/src/components/agentChat.tsx
@@ -216,39 +216,23 @@ export const AgentChat = ({ initialMessage = "", history = [], className = "", f
       </Card>
 
       {/* Input Area */}
-      <div className="mt-4 relative">
-        <div className="flex gap-2">
-          <Textarea
-            ref={textareaRef}
-            value={inputMessage}
-            onChange={(e) => handleInputChange(e.target.value)}
-            onKeyPress={handleKeyPress}
-            placeholder={t('agentChat.placeholder')}
-            className="flex-1 min-h-[60px] max-h-[120px] resize-none pb-8"
-            disabled={isLoading}
-          />
-          <Button
-            onClick={handleSendMessage}
-            disabled={!inputMessage.trim() || isLoading}
-            size="icon"
-            className="h-[60px] w-[60px] shrink-0"
-          >
-            {isLoading ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Send className="h-4 w-4" />
-            )}
-          </Button>
-        </div>
-        <div className="absolute bottom-1 right-16">
+      <div className="mt-4 rounded-md border bg-background shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50">
+        <Textarea
+          ref={textareaRef}
+          value={inputMessage}
+          onChange={(e) => handleInputChange(e.target.value)}
+          onKeyPress={handleKeyPress}
+          placeholder={t('agentChat.placeholder')}
+          className="max-h-[120px] min-h-[60px] resize-none border-0 shadow-none focus-visible:border-transparent focus-visible:ring-0"
+          disabled={isLoading}
+        />
+        <div className="flex items-center justify-between gap-2 px-2 pb-2">
           <Select
             value={selectedModel}
             onValueChange={(value) => setSelectedModel(value as AgentModel)}
+            disabled={isLoading}
           >
-            <SelectTrigger
-              className="h-6 text-xs px-2 border-none bg-muted/50 hover:bg-muted"
-              aria-label={t('agentChat.model') || 'Model'}
-            >
+            <SelectTrigger className="h-8 w-auto max-w-full border-0 bg-muted/50 px-2 text-xs shadow-none hover:bg-muted" aria-label={t('agentChat.model') || 'Model'}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -256,6 +240,18 @@ export const AgentChat = ({ initialMessage = "", history = [], className = "", f
               <SelectItem value="openai" disabled>OpenAI</SelectItem>
             </SelectContent>
           </Select>
+          <Button
+            onClick={handleSendMessage}
+            disabled={!inputMessage.trim() || isLoading}
+            size="icon"
+            className="shrink-0"
+          >
+            {isLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
+          </Button>
         </div>
       </div>
     </div>

--- a/src/views/dashboard/dashboardView.tsx
+++ b/src/views/dashboard/dashboardView.tsx
@@ -565,14 +565,22 @@ const aggregateDataByWeek = (dailyData: any[]) => {
       
       {isAgentChatEnabled && user?.id ? (
         <div className="mb-16">
-          <div className="flex flex-wrap gap-2 mb-4">
+          <div className="mb-4 grid w-full min-w-0 max-w-full grid-cols-1 gap-2 lg:grid-cols-3">
             {[
               'How did the user progress last week?',
               'What should we focus on during therapy today?',
               "What were the user's major life events this week?"
             ].map((question) => (
-              <Button key={question} variant="outline" size="sm" className="whitespace-normal text-left h-auto" onClick={() => setCurrentText(question)}>
-                {question}
+              <Button
+                key={question}
+                variant="outline"
+                size="sm"
+                className="h-auto w-full min-w-0 max-w-full flex-wrap justify-start whitespace-normal px-3 py-2 text-left"
+                onClick={() => setCurrentText(question)}
+              >
+                <span className="min-w-0 flex-1 whitespace-normal break-words [overflow-wrap:anywhere]">
+                  {question}
+                </span>
               </Button>
             ))}
           </div>


### PR DESCRIPTION
PLEASE REVIEW YOUR OWN PR BEFORE OPENING/UN-DRAFTING IT

# Fix assistant controls on mobile

Predefined assistant prompts overflowed narrow dashboard viewports, while the model selector overlapped the message textarea. This change constrains prompts to a responsive grid with explicitly wrapping labels and moves model selection and sending into a dedicated composer toolbar.

## Screenshots/Videocasts/Preview Links

N/A

## Have you?

- [x] Reviewed your own PR?
- [x] Tested your own feature/fix meets Acceptance Criteria?
- [ ] Made sure it passes all checks? (lint, build, integrations, scripts, etc)?
- [ ] Added screenshots? (if relevant)
- [x] Added unit tests? (if necessary)
- [x] Added documentation? (if necessary)

Targeted checks pass for the changed composer and dashboard JSX. The dashboard file still has unrelated pre-existing lint violations.

If so, THANKS! You can pop a beer/soda.

Please open your PR and ping your colleagues to review it on #web-devs channel.

Also, make sure to remind them on a daily basis during stand-up.