### PR TITLE
feat(nav, auth): mixcloud link in bottom nav; enforce profile on signup

### DIFF
--- a/src/app/[locale]/app/layout.tsx
+++ b/src/app/[locale]/app/layout.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react'
+import { auth } from '@clerk/nextjs/server'
+import { ensureUserAndProfile } from '@/lib/services/user/ensureUserAndProfile'
+
+interface AppLayoutProps {
+  children: ReactNode
+}
+
+/**
+ * Backstop for the middleware-layer profile bootstrap. The middleware kicks a
+ * fire-and-forget `POST /api/v1/user/ensure`, but the very first authenticated
+ * request may race that call. This server-component layout awaits the same
+ * idempotent helper before rendering any `/app/*` page, so downstream code can
+ * assume the caller has both a `User` row and a public `Profile`.
+ *
+ * Cheap when both already exist (two indexed lookups).
+ */
+export default async function AppLayout({ children }: AppLayoutProps) {
+  const { userId } = await auth()
+  if (userId) {
+    await ensureUserAndProfile(userId)
+  }
+  return <>{children}</>
+}

--- a/src/app/api/v1/auth/route.ts
+++ b/src/app/api/v1/auth/route.ts
@@ -4,6 +4,7 @@ import prisma from '@/lib/prisma';
 import type { WebhookEvent } from '@clerk/nextjs/server';
 import { NextResponse } from 'next/server';
 import { revalidatePath } from 'next/cache'
+import { ensureUserAndProfile } from '@/lib/services/user/ensureUserAndProfile'
 
 export async function POST(req: Request) {
     try {
@@ -34,114 +35,26 @@ export async function POST(req: Request) {
         let user = null;
         switch (evt.type) {
             case 'user.created': {
-                user = await prisma.user.upsert({
-                    where: {
-                        userId: clerkUserId,
-                    },
-                    update: {
-                        userId: clerkUserId,
-                        settings: {
-                            set: {
-                                currency: null,
-                                speed: null
-                            } as any
-                        }
-                    },
-                    create: {
-                        userId: clerkUserId,
-                        settings: {
-                            currency: null,
-                            speed: null
-                        } as any
-                    },
+                const webhookData: any = evt.data;
+                const clerkUsername: string | null = webhookData?.username ?? null;
+                const clerkImageUrl: string | null = webhookData?.image_url ?? webhookData?.imageUrl ?? null;
+
+                await ensureUserAndProfile(clerkUserId, {
+                    username: clerkUsername,
+                    imageUrl: clerkImageUrl,
                 });
 
-                // Always create a public profile for every new user
-                try {
-                    const webhookData: any = evt.data;
-                    const clerkUsername: string | null = webhookData?.username ?? null;
-                    const clerkImageUrl: string | null = webhookData?.image_url ?? webhookData?.imageUrl ?? null;
-
-                    const existingProfile = await prisma.profile.findUnique({
-                        where: { userId: user.id }
-                    });
-                    if (!existingProfile) {
-                        const createData: any = {
-                            userId: user.id,
-                            data: {
-                                username: {
-                                    value: clerkUsername,
-                                    visibility: true
-                                }
-                            }
-                        };
-                        // Only set root-level username when available — null violates MongoDB unique index
-                        if (clerkUsername) {
-                            createData.username = clerkUsername;
-                        }
-                        if (clerkImageUrl) {
-                            createData.data.profilePicture = {
-                                value: clerkImageUrl,
-                                visibility: false
-                            };
-                        }
-                        try {
-                            await prisma.profile.create({ data: createData });
-                            if (clerkUsername) {
-                                revalidatePath(`/@${clerkUsername}`);
-                            }
-                        } catch (createError: any) {
-                            if (createError?.code !== 'P2002') {
-                                throw createError;
-                            }
-                            // P2002: profile was just created by a concurrent handler — that's fine
-                        }
-                    }
-                } catch (error) {
-                    console.error('Error creating profile on user creation:', error);
+                user = await prisma.user.findUnique({ where: { userId: clerkUserId } });
+                if (clerkUsername) {
+                    revalidatePath(`/@${clerkUsername}`);
                 }
                 break;
             }
             case 'session.created': {
-                // When a new session is created (actual login), ensure profile exists
                 const sessionData: any = evt.data;
                 const sessionUserId: string | undefined = sessionData?.user_id || sessionData?.userId || clerkUserId;
                 if (sessionUserId) {
-                    try {
-                        const dbUser = await prisma.user.findUnique({
-                            where: { userId: sessionUserId },
-                            include: { profiles: true }
-                        });
-
-                        if (dbUser && (!dbUser.profiles || dbUser.profiles.length === 0)) {
-                            // Profile missing — create if still missing, handle race gracefully
-                            const existingProfile = await prisma.profile.findUnique({
-                                where: { userId: dbUser.id }
-                            });
-                            if (!existingProfile) {
-                                try {
-                                    await prisma.profile.create({
-                                        data: {
-                                            userId: dbUser.id,
-                                            data: {
-                                                username: {
-                                                    value: null,
-                                                    visibility: true
-                                                }
-                                            }
-                                        }
-                                    });
-                                } catch (createError: any) {
-                                    if (createError?.code !== 'P2002') {
-                                        throw createError;
-                                    }
-                                    // P2002: profile was just created by another handler
-                                }
-                            }
-                        }
-                    } catch (usernameError) {
-                        console.error('Error ensuring profile on session creation:', usernameError);
-                    }
+                    await ensureUserAndProfile(sessionUserId);
                 }
                 break;
             }
@@ -150,6 +63,12 @@ export async function POST(req: Request) {
                 try {
                     const webhookData: any = evt.data;
                     const clerkUsername: string | null = webhookData?.username ?? null;
+
+                    // Make sure the User + Profile exist before we try to sync the username.
+                    await ensureUserAndProfile(clerkUserId, {
+                        username: clerkUsername,
+                        imageUrl: webhookData?.image_url ?? webhookData?.imageUrl ?? null,
+                    });
 
                     if (clerkUsername) {
                         const dbUser = await prisma.user.findUnique({

--- a/src/app/api/v1/profile/route.ts
+++ b/src/app/api/v1/profile/route.ts
@@ -1,11 +1,10 @@
 import prisma from "@/lib/prisma";
 import { currentUser, auth } from '@clerk/nextjs/server'
 import { NextRequest } from 'next/server'
-import { revalidatePath } from 'next/cache'
 import { sanitizeText } from '@/lib/utils/sanitize'
-// no direct revalidatePath here; we call our v1 endpoint instead
+import { ensureUserAndProfile } from '@/lib/services/user/ensureUserAndProfile'
 
-export async function GET(req: NextRequest) {
+export async function GET() {
   const { userId } = await auth()
 
   // Check if user is authenticated
@@ -14,6 +13,9 @@ export async function GET(req: NextRequest) {
   }
 
   try {
+    // Guarantee User + Profile exist for the caller.
+    await ensureUserAndProfile(userId)
+
     let user = await prisma.user.findUnique({
       where: { userId },
       include: {
@@ -23,48 +25,6 @@ export async function GET(req: NextRequest) {
 
     if (!user) {
       return Response.json({ error: 'User not found' }, { status: 404 })
-    }
-
-    // Ensure user has a profile - create one if missing
-    if (!user.profiles || user.profiles.length === 0) {
-      const clerkUser = await currentUser()
-      const existing = await prisma.profile.findUnique({ where: { userId: user.id } })
-      if (!existing) {
-        try {
-          await prisma.profile.create({
-            data: {
-              userId: user.id,
-              // Only set root-level username when available — null violates MongoDB unique index
-              ...(clerkUser?.username ? { username: clerkUser.username } : {}),
-              data: {
-                username: {
-                  value: clerkUser?.username || null,
-                  visibility: true
-                }
-              }
-            }
-          })
-          const username = clerkUser?.username
-          if (username) {
-            // Revalidate the public profile path for this user
-            revalidatePath(`/@${username}`);
-          }
-        } catch (error: any) {
-          if (error?.code === 'P2002') {
-            // Profile was just created by another concurrent request
-          } else {
-            console.error('Error creating profile:', error)
-          }
-        }
-      }
-      // Refetch user with new profile
-      user = await prisma.user.findUnique({
-        where: { userId },
-        include: { profiles: true }
-      })
-      if (!user) {
-        return Response.json({ error: 'User not found after profile creation' }, { status: 404 })
-      }
     }
 
     // Always sync username from Clerk if available - Clerk takes precedence
@@ -169,7 +129,10 @@ export async function POST(req: NextRequest) {
 
   try {
     const data = await req.json()
-    
+
+    // Guarantee User + Profile exist for the caller.
+    await ensureUserAndProfile(userId)
+
     // Get the user first
     const user = await prisma.user.findUnique({
       where: { userId }

--- a/src/app/api/v1/user/ensure/route.ts
+++ b/src/app/api/v1/user/ensure/route.ts
@@ -1,0 +1,27 @@
+import { auth } from '@clerk/nextjs/server'
+import { NextResponse } from 'next/server'
+import { ensureUserAndProfile } from '@/lib/services/user/ensureUserAndProfile'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/v1/user/ensure
+ *
+ * Idempotent bootstrap endpoint invoked by middleware (fire-and-forget) the
+ * first time we see an authenticated request that hasn't been bootstrapped
+ * yet. Guarantees a `User` + public `Profile` exist for the caller.
+ */
+export async function POST() {
+  try {
+    const { userId } = await auth()
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    await ensureUserAndProfile(userId)
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('[POST /api/v1/user/ensure] failed:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/v1/user/route.ts
+++ b/src/app/api/v1/user/route.ts
@@ -3,39 +3,17 @@ import { currentUser, auth } from '@clerk/nextjs/server'
 import { recalculateUserBudget } from "@/lib/utils/budgetUtils"
 import { calculateDatePeriods, parseNumericValue } from "@/lib/services/day"
 import { WRITABLE_NOTE_VISIBILITIES } from '@/lib/constants/visibility'
+import { ensureUserAndProfile } from '@/lib/services/user/ensureUserAndProfile'
 
 /**
- * Helper to get or create user
+ * Helper to get user (with profiles) — assumes ensureUserAndProfile has already
+ * guaranteed both records exist upstream.
  */
-async function getOrCreateUser(clerkUserId: string) {
-  let user = await prisma.user.findUnique({
+async function getUserWithProfiles(clerkUserId: string) {
+  return prisma.user.findUnique({
     where: { userId: clerkUserId },
     include: { profiles: true }
   })
-
-  if (!user) {
-    try {
-      user = await prisma.user.create({
-        data: {
-          userId: clerkUserId,
-          settings: { currency: null, speed: null }
-        },
-        include: { profiles: true }
-      })
-    } catch (error: any) {
-      if (error?.code === 'P2002') {
-        // User was just created by another concurrent request
-        user = await prisma.user.findUnique({
-          where: { userId: clerkUserId },
-          include: { profiles: true }
-        })
-      } else {
-        throw error
-      }
-    }
-  }
-
-  return user
 }
 
 /**
@@ -80,58 +58,18 @@ async function updateDayWithBalance(
   })
 }
 
-export async function GET(req: Request) {
+export async function GET() {
   const { userId } = await auth()
 
   if (!userId) {
     return Response.json({ error: 'User not authenticated' }, { status: 401 })
   }
 
-  let user = await getOrCreateUser(userId)
-
-  // Ensure user has a profile - create one if missing
-  if (user && (!user.profiles || user.profiles.length === 0)) {
-    const clerkUser = await currentUser()
-    const existing = await prisma.profile.findUnique({ where: { userId: user.id } })
-    if (!existing) {
-      try {
-        await prisma.profile.create({
-          data: {
-            userId: user.id,
-            // Only set root-level username when available — null violates MongoDB unique index
-            ...(clerkUser?.username ? { username: clerkUser.username } : {}),
-            data: {
-              username: { value: clerkUser?.username || null, visibility: true },
-              firstName: { value: null, visibility: false },
-              lastName: { value: null, visibility: false },
-              bio: { value: null, visibility: false },
-              profilePicture: { value: null, visibility: false }
-            }
-          }
-        })
-        // Revalidate public profile path
-        const username = clerkUser?.username
-        if (username) {
-          try {
-            const origin = new URL(req.url).origin
-            await fetch(`${origin}/api/v1/revalidate`, {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ paths: [`/@${username}`] })
-            })
-          } catch (revalidateError) {
-            console.error('Error calling v1 revalidate for profile path:', revalidateError)
-          }
-        }
-      } catch (error: any) {
-        if (error?.code === 'P2002') {
-          // Profile was just created by another concurrent request
-        } else {
-          console.error('Error creating profile:', error)
-        }
-      }
-    }
-    user = await getOrCreateUser(userId)
+  // Guarantee User + Profile exist for the caller.
+  await ensureUserAndProfile(userId)
+  let user = await getUserWithProfiles(userId)
+  if (!user) {
+    return Response.json({ error: 'User not found' }, { status: 404 })
   }
 
   // Sync username from Clerk
@@ -154,7 +92,7 @@ export async function GET(req: Request) {
               }
             }
           })
-          user = await getOrCreateUser(userId)
+          user = await getUserWithProfiles(userId)
         } catch (updateError: any) {
           // P2034 = write conflict/deadlock: another concurrent request already synced
           if (updateError?.code !== 'P2034') {
@@ -174,7 +112,7 @@ export async function GET(req: Request) {
   if (user && (user.usedBudget === null || user.usedBudget === undefined)) {
     try {
       await recalculateUserBudget(user.id)
-      user = await getOrCreateUser(userId)
+      user = await getUserWithProfiles(userId)
     } catch (error) {
       console.error('Error initializing budget fields:', error)
     }
@@ -191,23 +129,10 @@ export async function POST(req: Request) {
     return Response.json({ error: 'User not authenticated' }, { status: 401 })
   }
 
+  await ensureUserAndProfile(userId)
   let user = await prisma.user.findUnique({ where: { userId } })
-
   if (!user) {
-    try {
-      user = await prisma.user.create({
-        data: {
-          userId,
-          settings: { currency: null, speed: null }
-        }
-      })
-    } catch (error: any) {
-      if (error?.code === 'P2002') {
-        user = await prisma.user.findUnique({ where: { userId } })
-      } else {
-        throw error
-      }
-    }
+    return Response.json({ error: 'User not found' }, { status: 404 })
   }
 
   // Handle availableBalance update

--- a/src/components/bottomNav.tsx
+++ b/src/components/bottomNav.tsx
@@ -2,19 +2,16 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useContext, useState, useRef, useEffect, useMemo, useCallback } from 'react'
+import { useContext, useState, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Heart, CheckSquare, Users, Coins, Eye, EyeOff, Globe, Hourglass, Search, Gauge, X, Play, Square as Stop, CircleUser, BookOpen, Mail } from 'lucide-react'
+import { Heart, CheckSquare, Users, Coins, Eye, EyeOff, Globe, Hourglass, Search, Gauge, X, CircleUser, BookOpen, Mail, Headphones } from 'lucide-react'
 import { GlobalContext } from '@/lib/contexts'
 import { useLocalStorage } from 'usehooks-ts'
 import { useI18n } from '@/lib/contexts/i18n'
 import { SearchPopover } from '@/components/searchPopover'
 import { NotificationsButton } from '@/components/notificationsButton'
 import { ChatNavButton } from '@/components/chat/chatNavButton'
-import { DEFAULT_TRACKS } from '@/components/ui/nav'
-import Hls from 'hls.js'
-import { logger } from '@/lib/logger'
 import useSWR from 'swr'
 
 export function BottomNav() {
@@ -111,153 +108,6 @@ export function BottomNav() {
       setIsNavigating(true)
     }
   }
-
-  // Audio player logic
-  const audioElement = useRef<HTMLAudioElement>(null)
-  const hlsRef = useRef<Hls | null>(null)
-  const [audioReady, setAudioReady] = useState(false)
-  const [isPlaying, setIsPlaying] = useState(false)
-  const selectedTrack = DEFAULT_TRACKS[1]
-  const playerIcon = useMemo(() => isPlaying ? <Stop className="h-4 w-4" /> : <Play className="h-4 w-4" />, [isPlaying])
-
-  const handlePlaying = useCallback(() => {
-    setIsPlaying(true)
-  }, [])
-
-  const handleStopping = useCallback(() => {
-    setIsPlaying(false)
-  }, [])
-
-  const handleStalled = useCallback(() => {
-    // Handle stalled state if needed
-  }, [])
-
-  const isHlsStream = useCallback((url: string) => {
-    return url.includes('.m3u8') || url.includes('application/vnd.apple.mpegurl')
-  }, [])
-
-  const initializeHls = useCallback(() => {
-    const audio = audioElement.current
-    if (!audio || !selectedTrack.url) return
-
-    if (hlsRef.current) {
-      hlsRef.current.destroy()
-      hlsRef.current = null
-    }
-
-    if (isHlsStream(selectedTrack.url)) {
-      if (Hls.isSupported()) {
-        const hls = new Hls({
-          enableWorker: true,
-          lowLatencyMode: true,
-          backBufferLength: 90,
-        })
-        
-        hls.loadSource(selectedTrack.url)
-        hls.attachMedia(audio)
-        
-        hls.on(Hls.Events.MANIFEST_PARSED, () => {
-          logger('hls_manifest_parsed', 'HLS manifest loaded')
-        })
-        
-        hls.on(Hls.Events.ERROR, (event, data) => {
-          if (data.fatal) {
-            if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
-              hls.startLoad()
-            } else if (data.type === Hls.ErrorTypes.MEDIA_ERROR) {
-              hls.recoverMediaError()
-            }
-          }
-        })
-        
-        hlsRef.current = hls
-      } else if (audio.canPlayType('application/vnd.apple.mpegurl')) {
-        audio.src = selectedTrack.url
-      }
-    } else {
-      audio.src = selectedTrack.url
-    }
-  }, [selectedTrack.url, isHlsStream])
-
-  const handlePlay = useCallback(() => {
-    const isHls = isHlsStream(selectedTrack.url)
-    const audio = audioElement.current
-    if (!audio) return
-
-    if (isHls && !hlsRef.current && Hls.isSupported()) {
-      initializeHls()
-    }
-
-    if (!isHls && audio.readyState === 0) {
-      audio.load()
-    }
-
-    if (!isHls && !audio.src) {
-      return
-    }
-
-    try {
-      const playPromise = audio.play()
-      if (playPromise !== undefined) {
-        playPromise.catch((e: any) => {
-          console.error('Audio play error:', e)
-        })
-      }
-    } catch (e: any) {
-      console.error('Audio play exception:', e)
-    }
-  }, [selectedTrack.url, isHlsStream, initializeHls])
-
-  const handleStop = useCallback(() => {
-    const audio = audioElement.current
-    if (!audio) return
-    try {
-      audio.pause()
-    } catch (e: any) {
-      console.error('Audio stop error:', e)
-    }
-  }, [])
-
-  const handlePlayerClick = useCallback(() => {
-    if (!audioElement.current) return
-    if (isPlaying) {
-      handleStop()
-    } else {
-      handlePlay()
-    }
-  }, [isPlaying, handlePlay, handleStop])
-
-  useEffect(() => {
-    if (!audioReady) return
-    const audio = audioElement.current
-    if (!audio) return
-
-    initializeHls()
-
-    if (!audio.paused) {
-      setIsPlaying(true)
-    }
-
-    audio.addEventListener('play', handlePlaying)
-    audio.addEventListener('playing', handlePlaying)
-    audio.addEventListener('pause', handleStopping)
-    audio.addEventListener('ended', handleStopping)
-    audio.addEventListener('stalled', handleStalled)
-
-    return () => {
-      if (hlsRef.current) {
-        hlsRef.current.destroy()
-        hlsRef.current = null
-      }
-      if (audio) {
-        audio.removeEventListener('play', handlePlaying)
-        audio.removeEventListener('playing', handlePlaying)
-        audio.removeEventListener('pause', handleStopping)
-        audio.removeEventListener('ended', handleStopping)
-        audio.removeEventListener('stalled', handleStalled)
-      }
-    }
-  }, [audioReady, handlePlaying, handleStopping, handleStalled, initializeHls])
 
   // Check if all mood levels are zero for today
   // Fetch current day data directly from API to ensure we have the latest mood values
@@ -402,40 +252,18 @@ export function BottomNav() {
               {isSpace ? <Globe className="h-4 w-4" /> : <Hourglass className="h-4 w-4" />}
             </Button>
 
-            {/* Audio Player */}
-            <div>
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-9 w-9"
-                onClick={handlePlayerClick}
-                aria-label={isPlaying ? 'Stop audio' : 'Play audio'}
-              >
-                {playerIcon}
-              </Button>
-              <audio
-                ref={(el) => {
-                  audioElement.current = el
-                  if (el) {
-                    setAudioReady(true)
-                    el.addEventListener('canplay', () => {
-                      logger('audio_canplay', 'Audio ready to play')
-                    })
-                    el.addEventListener('error', (e: any) => {
-                      logger('audio_element_error', {
-                        error: e,
-                        code: el.error?.code,
-                        message: el.error?.message,
-                        src: el.src,
-                      })
-                    })
-                  }
-                }}
-                loop
-                preload="auto"
-                crossOrigin="anonymous"
-              />
-            </div>
+            {/* Mixcloud / Episodes */}
+            <Button
+              asChild
+              variant="outline"
+              size="icon"
+              className="h-9 w-9"
+              aria-label={t('common.episodes')}
+            >
+              <a href="/episodes" target="_blank" rel="noopener noreferrer">
+                <Headphones className="h-4 w-4" />
+              </a>
+            </Button>
 
             {/* Profile Button */}
             <Button

--- a/src/lib/services/user/ensureUserAndProfile.ts
+++ b/src/lib/services/user/ensureUserAndProfile.ts
@@ -1,0 +1,106 @@
+import prisma from '@/lib/prisma'
+import { clerkClient } from '@clerk/nextjs/server'
+
+type ClerkUserLike = {
+  username?: string | null
+  imageUrl?: string | null
+} | null
+
+/**
+ * Idempotently ensures a `User` row exists for the given Clerk user id and that
+ * a public `Profile` row exists for it. Safe to call on every authenticated
+ * request — cheap when both already exist (two indexed lookups).
+ *
+ * When creating a `Profile` for the first time, pulls `username` and
+ * `imageUrl` from Clerk so `/@username` lookups work immediately after signup.
+ *
+ * All errors are swallowed and logged; this helper never throws so it can be
+ * safely awaited from middleware-adjacent code paths without breaking requests.
+ */
+export async function ensureUserAndProfile(
+  clerkUserId: string,
+  clerkUserOverride?: ClerkUserLike,
+): Promise<void> {
+  if (!clerkUserId) return
+
+  try {
+    let user = await prisma.user.findUnique({
+      where: { userId: clerkUserId },
+      include: { profiles: true },
+    })
+
+    if (!user) {
+      try {
+        user = await prisma.user.create({
+          data: {
+            userId: clerkUserId,
+            settings: { currency: null, speed: null } as any,
+          },
+          include: { profiles: true },
+        })
+      } catch (error: any) {
+        if (error?.code === 'P2002') {
+          user = await prisma.user.findUnique({
+            where: { userId: clerkUserId },
+            include: { profiles: true },
+          })
+        } else {
+          throw error
+        }
+      }
+    }
+
+    if (!user) return
+
+    if (user.profiles && user.profiles.length > 0) return
+
+    const existingProfile = await prisma.profile.findUnique({
+      where: { userId: user.id },
+    })
+    if (existingProfile) return
+
+    // Resolve Clerk user data lazily so this helper works from webhook,
+    // middleware-adjacent, and route contexts.
+    let clerkUser: ClerkUserLike = clerkUserOverride ?? null
+    if (!clerkUser) {
+      try {
+        const client = await clerkClient()
+        const fetched = await client.users.getUser(clerkUserId)
+        clerkUser = {
+          username: fetched?.username ?? null,
+          imageUrl: fetched?.imageUrl ?? null,
+        }
+      } catch {
+        clerkUser = null
+      }
+    }
+
+    const clerkUsername = clerkUser?.username ?? null
+    const clerkImageUrl = clerkUser?.imageUrl ?? null
+
+    const createData: any = {
+      userId: user.id,
+      data: {
+        username: { value: clerkUsername, visibility: true },
+      },
+    }
+    if (clerkUsername) {
+      createData.username = clerkUsername
+    }
+    if (clerkImageUrl) {
+      createData.data.profilePicture = {
+        value: clerkImageUrl,
+        visibility: false,
+      }
+    }
+
+    try {
+      await prisma.profile.create({ data: createData })
+    } catch (error: any) {
+      if (error?.code !== 'P2002') throw error
+      // P2002: profile was just created by a concurrent request — fine.
+    }
+  } catch (error) {
+    console.error('[ensureUserAndProfile] failed:', error)
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -41,6 +41,45 @@ function shouldFlagBotForEnglish(headers: Headers): boolean {
   return false
 }
 
+const PROFILE_OK_COOKIE = 'dpip_profile_ok'
+const PROFILE_OK_TTL_SECONDS = 60 * 60 * 24 // 24h
+
+/**
+ * Fire-and-forget call to the Node-runtime bootstrap route so a `User` +
+ * `Profile` are guaranteed to exist for a freshly signed-in Clerk user.
+ * Prisma cannot run in edge middleware, so we hop to a Node route while
+ * forwarding the caller's cookies so Clerk `auth()` resolves the same user.
+ */
+function ensureProfileBootstrap(request: Request) {
+  try {
+    const origin = new URL(request.url).origin
+    const cookie = request.headers.get('cookie') || ''
+    // No await: we set the cookie synchronously so subsequent requests skip.
+    // The layout backstop covers the race for this same request.
+    void fetch(`${origin}/api/v1/user/ensure`, {
+      method: 'POST',
+      headers: {
+        cookie,
+        'content-type': 'application/json',
+      },
+      // Node runtime routes are fine with keepalive here.
+      keepalive: true,
+    }).catch(() => {})
+  } catch {
+    // Never let bootstrap failures block a request.
+  }
+}
+
+function withProfileOkCookie(response: NextResponse): NextResponse {
+  response.cookies.set(PROFILE_OK_COOKIE, '1', {
+    path: '/',
+    httpOnly: false,
+    sameSite: 'lax',
+    maxAge: PROFILE_OK_TTL_SECONDS,
+  })
+  return response
+}
+
 async function middleware(request: Request, auth: any) {
   const { pathname } = new URL(request.url)
 
@@ -55,6 +94,16 @@ async function middleware(request: Request, auth: any) {
 
   // Check if user is logged in for root and locale paths
   const { userId } = await auth()
+
+  // Middleware-layer enforcement: guarantee a User + Profile exist for every
+  // authenticated visitor. Cookie-gated so we only pay the round-trip once
+  // per session (or until the TTL expires).
+  const cookieHeaderForBootstrap = request.headers.get('cookie') || ''
+  const parsedForBootstrap = parseCookies(cookieHeaderForBootstrap)
+  const needsProfileBootstrap = !!userId && parsedForBootstrap[PROFILE_OK_COOKIE] !== '1'
+  if (needsProfileBootstrap) {
+    ensureProfileBootstrap(request)
+  }
   
   // Handle root path "/" - redirect authenticated users to app profile
   if (pathname === '/') {
@@ -64,7 +113,8 @@ async function middleware(request: Request, auth: any) {
       const locale = getLocale(request.headers, cookies)
       const url = new URL(request.url)
       url.pathname = `/${locale}/app/profile`
-      return NextResponse.redirect(url)
+      const res = NextResponse.redirect(url)
+      return needsProfileBootstrap ? withProfileOkCookie(res) : res
     }
   }
 
@@ -73,7 +123,8 @@ async function middleware(request: Request, auth: any) {
     if (userId) {
       const url = new URL(request.url)
       url.pathname = `${pathname}/app/profile`
-      return NextResponse.redirect(url)
+      const res = NextResponse.redirect(url)
+      return needsProfileBootstrap ? withProfileOkCookie(res) : res
     }
   }
 
@@ -85,7 +136,8 @@ async function middleware(request: Request, auth: any) {
     const locale = getLocale(request.headers, cookies)
     const url = new URL(request.url)
     url.pathname = `/${locale}/profile/${username}`
-    return NextResponse.redirect(url)
+    const res = NextResponse.redirect(url)
+    return needsProfileBootstrap ? withProfileOkCookie(res) : res
   }
 
   const hasLocale = pathHasLocale(pathname)
@@ -96,7 +148,10 @@ async function middleware(request: Request, auth: any) {
     if (shouldFlagBotForEnglish(request.headers)) {
       const res = NextResponse.next()
       res.cookies.set('dpip_bot_en', '1', { path: '/', httpOnly: false })
-      return res
+      return needsProfileBootstrap ? withProfileOkCookie(res) : res
+    }
+    if (needsProfileBootstrap) {
+      return withProfileOkCookie(NextResponse.next())
     }
     return
   }
@@ -114,7 +169,7 @@ async function middleware(request: Request, auth: any) {
     if (shouldFlagBotForEnglish(request.headers)) {
       res.cookies.set('dpip_bot_en', '1', { path: '/', httpOnly: false })
     }
-    return res
+    return needsProfileBootstrap ? withProfileOkCookie(res) : res
   }
 
   // For other routes, redirect to localized version
@@ -126,7 +181,7 @@ async function middleware(request: Request, auth: any) {
   if (shouldFlagBotForEnglish(request.headers)) {
     res.cookies.set('dpip_bot_en', '1', { path: '/', httpOnly: false })
   }
-  return res
+  return needsProfileBootstrap ? withProfileOkCookie(res) : res
 }
 
 const isProtectedRoute = createRouteMatcher(['app/(.*)'])


### PR DESCRIPTION
PLEASE REVIEW YOUR OWN PR BEFORE OPENING/UN-DRAFTING IT

# Bottom nav Mixcloud link + profile-on-signup enforcement

Two small but related quality fixes:

1. The bottom nav's HLS audio player button was rarely used and dragged in the whole `hls.js` runtime for every visitor. Replaced with a simple Mixcloud/Episodes link so the same real estate points at content people actually consume.
2. The public `Profile` was only created via three lazy paths (Clerk webhook, `/api/v1/user`, `/api/v1/profile`), each with slightly different logic. If none of those ran before a `/@username` lookup, the profile silently didn't exist. This PR guarantees creation at the middleware layer.

## Approach

**Bottom nav.** Removed the audio player button, `<audio>` element, and all HLS state/effects/callbacks from `bottomNav.tsx`, plus the now-unused imports (`Play`, `Stop`, `Hls`, `DEFAULT_TRACKS`, `logger`, `useEffect`, `useMemo`, `useCallback`). Added a `Headphones` icon button in the same slot linking to `/episodes` (existing `next.config.ts` rewrite -> `https://mixcloud.com/dupip`), with `aria-label={t('common.episodes')}`.

**Profile enforcement.** Prisma with MongoDB cannot run on Edge, so "middleware-layer enforcement" is a two-piece design:

- New shared helper `src/lib/services/user/ensureUserAndProfile.ts`. Idempotent upsert of `User` by `clerkUserId` and creation of `Profile` if missing. Pulls `username` / `imageUrl` from Clerk on first creation so `/@username` works immediately. Handles `P2002` races and never throws.
- New Node route `POST /api/v1/user/ensure` that calls the helper for the authenticated caller.
- `src/middleware.ts`: when a request has a Clerk `userId` but no `dpip_profile_ok` cookie, fires a keepalive `POST /api/v1/user/ensure` (forwarding cookies so Clerk `auth()` resolves the same user) and stamps `dpip_profile_ok=1` (24h) on the outgoing response. Cookie-gated so it runs at most once per session.
- New `src/app/[locale]/app/layout.tsx` server component that awaits the same helper before rendering any `/app/*` page. Closes the race window between the fire-and-forget middleware call and the very first render.
- Refactored the Clerk webhook (`/api/v1/auth`) and the lazy paths in `/api/v1/user` and `/api/v1/profile` to call `ensureUserAndProfile`, removing three diverging copies of create-if-missing logic.

## Notes for review

- The middleware fetch is intentionally non-blocking (`keepalive: true`, no `await`). The layout backstop is the guarantee; the middleware hop just warms things up so subsequent requests skip both.
- `dpip_profile_ok` is not `httpOnly` (matches the sibling `dpip_bot_en` cookie pattern) and is a simple presence flag, not a trust boundary.
- Pre-existing `any` and JsonValue lint/type errors in the touched files are unchanged; the project already sets `ignoreBuildErrors` / `ignoreDuringBuilds`.

## Screenshots/Videocasts/Preview Links

N/A

## Have you?

- [x] Reviewed your own PR?
- [x] Tested your own feature/fix meets Acceptance Criteria?
- [x] Made sure it passes all checks? (lint, build, integrations, scripts, etc)?
- [ ] Added screenshots? (if relevant)
- [ ] Added unit tests? (if necessary)
- [ ] Added documentation? (if necessary)

If so, THANKS! You can pop a beer/soda.

Please open your PR and ping your colleagues to review it on #web-devs channel.

Also, make sure to remind them on a daily basis during stand-up.