### PR TITLE
docs(plans): consolidate Do + Be roadmap into phased plan files

### DIFF
--- a/docs/do-rebuild-plan.md
+++ b/docs/do-rebuild-plan.md
@@ -1,5 +1,11 @@
 # Do Module Rebuild — Follow-up on #441
 
+> **Superseded.** Phases 1 and 2 of this document are implemented and merged. The remaining work
+> (Phases 3 and 4) has been folded into the consolidated program plan at
+> [`docs/plans/README.md`](./plans/README.md), which also covers the Be module (events, ticketing,
+> DPIP ledger, organizations, subscription allowances). Keep this file for the Phase 1–2 rationale
+> and findings; do not plan new work from it.
+
 ## Context
 
 Issue #441 ("r0.1.0") merged the Do module as it stands: budgets with distribution modes (#298/#299), Task-collection integration replacing templateTasks/ephemeralTasks (#302/#310), job earnings/invoice (#307/#315), CANCELLED-status compliance (#313). Those incremental PRs left the module overly complex: a 951-line addListForm with area/category/per-task budget distributions, a multiplexed `tasklists` POST, legacy fallbacks, duplicated loading paths, and **two parallel completion systems** (legacy embedded completers vs job-based) both mutating user money.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,109 @@
+# Dupip Roadmap — Do consolidation → Be events & ticketing
+
+Consolidated program plan. Supersedes `docs/do-rebuild-plan.md` (kept for history; Phases 1–2
+of that document are **already merged on this branch**).
+
+One file per phase. Each phase is one PR unless stated otherwise.
+
+## Status
+
+| # | Phase | Scope | Status | File |
+|---|-------|-------|--------|------|
+| 1 | Do — model + API + migrations | RRULE cadence, simplified budgets, thin routes, migrations 0017–0019 | ✅ done | `../do-rebuild-plan.md` §Phase 1 |
+| 2 | Do — frontend rebuild | doPage/doView/taskGrid/forms rebuilt on plain SWR | ✅ done | `../do-rebuild-plan.md` §Phase 2 |
+| 3 | Do dry-out + shared primitives | Kill remaining duplication, extract ownership/social/public-page/date kits | ⬜ planned | `phase-03-do-dry-out.md` |
+| 4 | Media, storage & geolocation foundation | iDrive e2 uploads, compression, EXIF, Google Places, map, Write composer | ⬜ planned | `phase-04-media-geo-foundation.md` |
+| 5 | Public list profiles + job board | Public list pages, public tasks as job posts, applications | ⬜ planned | `phase-05-public-lists-job-board.md` |
+| 6 | DPIP ledger & wallets | Off-chain authoritative balances, atomic transfers, wallet at signup | ⬜ planned | `phase-06-dpip-ledger.md` |
+| 7 | Organizations | Clerk Orgs mirror, org profiles/lists/wallets, polymorphic ownership | ⬜ planned | `phase-07-organizations.md` |
+| 8 | Events core | Event model, event pages, `/app/be/events` listing, RSVP/social | ⬜ planned | `phase-08-events-core.md` |
+| 9 | Ticketing & checkout | Tiers, promo windows, bundles, buy/reserve with DPIP, escrow | ⬜ planned | `phase-09-ticketing.md` |
+| 10 | QR attendance & door control | Rotating signed QR, scanner API + UI, attendance records, pay-at-door | ⬜ planned | `phase-10-qr-attendance.md` |
+| 11 | Subscription DPIP allowances | Plan catalog, Clerk billing webhook + cron top-ups, idempotent grants | ⬜ planned | `phase-11-subscription-allowances.md` |
+
+## Dependency graph
+
+```mermaid
+graph TD
+  P3[3 Do dry-out<br/>shared primitives] --> P5[5 Public lists + job board]
+  P4[4 Media + geo foundation] --> P5
+  P4 --> P8[8 Events core]
+  P3 --> P8
+  P6[6 DPIP ledger] --> P9[9 Ticketing]
+  P6 --> P11[11 Subscription allowances]
+  P7[7 Organizations] --> P8
+  P8 --> P9
+  P9 --> P10[10 QR attendance]
+  P5 --> P8
+```
+
+Phases 3, 4, 6 are independent of each other and can run in parallel. 7 can start any time after 3.
+9 is the only hard blocker for 10. 11 only needs 6.
+
+## Confirmed decisions
+
+1. **DPIP ledger** — an authoritative **off-chain ledger** (`Wallet.balance` + double-entry
+   `LedgerEntry` rows behind every `Transaction`) is the source of truth. Kaleido stays for
+   on-chain mint/NFT and becomes an optional mirror reconciled later (`Transaction.onChainTxHash`,
+   `Wallet.onChainSyncedAt`). No Kaleido call is on the critical path of a ticket purchase.
+2. **Organizations** — Clerk Organizations remain the identity/membership source of truth
+   (already used by chat via `ChatOrgMembership`). We add a Prisma `Organization` mirror and a
+   polymorphic owner (`ownerType: USER | ORG` + `orgId`) on `Profile`, `List`, `Event`, `Wallet`.
+3. **Data preservation** — every destructive schema change ships with an idempotent migration in
+   `src/migrations/` and snapshots dropped fields into a `legacy Json?` column (established in
+   Phases 1–2). Next free migration number: **0020**.
+4. **Delivery** — one PR per phase, each self-verifiable with `npx prisma generate && npm run build
+   && npm run lint` plus the manual checklist at the end of each phase file.
+5. **Money is never trusted from the client** — prices, discounts, deposits and balances are
+   recomputed server-side on every write (existing rule for job earnings; extended to tickets).
+
+## Cross-cutting conventions (apply to every phase)
+
+- **Routes** are thin: `await auth()` → resolve internal `User` → authorize → call a service in
+  `src/lib/services/**` → return `{ resource }` or `{ error }`. No business logic in route files.
+- **Sanitize** all user text with `sanitizeText`/`sanitizeHTML` from `@/lib/utils/sanitize`.
+- **Docs** — every new/changed route updates `src/app/api/openapi.yaml` and the nearest
+  `CLAUDE.md`; every new view directory gets a `CLAUDE.md`.
+- **i18n** — new copy goes to `src/locales/en.json` first, then propagates to all 33 locales via
+  the `the-i18n` skill / `scripts/translate-new-keys.js`. No hardcoded strings in components.
+- **Money type** — all DPIP amounts are persisted as **integer minor units** (`Int`, 1 DPIP =
+  100 units). Prisma-on-Mongo has no `Decimal`, and `Float` balances drift under `$inc` and break
+  `{ gte: amount }` comparisons, so no monetary value is ever stored as a float. Conversion happens
+  only at the API/UI boundary via `src/lib/utils/money.ts` (Phase 6). Existing float money fields
+  (`User.stash`, `Job.earnings`, …) are out of scope and stay as they are; new value-bearing fields
+  are minor units.
+- **Schema validity per phase** — Prisma requires both sides of a relation in the same schema, so a
+  relation field is only added in the phase that introduces both models. Where a later phase adds
+  the counterpart (e.g. `Event.tiers` in Phase 9), the earlier phase's schema block omits it and
+  the later phase's file states the inverse fields it must add.
+- **Idempotency** — any endpoint that moves value (transfer, purchase, check-in, allowance grant)
+  takes or derives an idempotency key persisted as `Transaction.reference @unique`.
+- **Visibility** — reuse `src/lib/services/visibility/visibilityService.ts`
+  (`buildVisibilityWhereClause`, `batchEnrichUserProfiles`) for every new public feed query.
+
+## Verification ritual (per PR)
+
+```bash
+npx prisma generate
+npm run build
+npm run lint
+node src/migrations/<new-migration>.js   # dev DB, then re-run to prove idempotency
+```
+
+Then the phase's manual checklist. Commits via the `the-committer` skill; migrations via
+`the-migrator`; locale fan-out via `the-i18n`.
+
+## Risks tracked across the program
+
+| Risk | Mitigation | Phase |
+|------|-----------|-------|
+| Float drift on balances | Integer minor units everywhere + ledger reconciliation job | 6 |
+| Partial writes when money moves | Interactive `prisma.$transaction` on the Atlas replica set wraps every debit+credit+entries+status; a recovery sweep resumes abandoned `PENDING` rows | 6, 9, 10 |
+| Overselling tickets | Conditional claim on **both** `TicketTier.sold` and `Event.soldCount` inside the checkout transaction; reservations expire via cron | 9 |
+| QR screenshot sharing | Rotating HMAC token bound to a per-ticket secret, single-use check-in, fail-closed offline | 10 |
+| Nullable `@unique` slugs are not sparse on Mongo | Slugs are required and generated at creation, never null | 5, 7, 8 |
+| Clerk billing event names differ per Clerk version | Webhook handler is event-name tolerant + daily cron reconciles **against Clerk's own subscription list**, not just local mirrors | 11 |
+| Disguised uploads served from our origin | Magic-byte inspection server-side + isolated media origin with forced download/`Content-Security-Policy` headers | 4 |
+| Vercel 4.5 MB body limit | Presigned direct-to-S3 uploads | 4 |
+| 33 locales × new keys per phase | en.json is source of truth, scripted fan-out | all |
+| Legacy `Event` (life events) colliding with public events | Rename to `LifeEvent` with a copy-then-delete migration | 8 |

--- a/docs/plans/phase-03-do-dry-out.md
+++ b/docs/plans/phase-03-do-dry-out.md
@@ -1,0 +1,127 @@
+# Phase 3 — Do dry-out + shared primitives
+
+**Goal:** finish the Do consolidation started in Phases 1–2 and extract the primitives that Be
+(lists, events, tickets, orgs) will reuse, so the Be work adds features instead of copies.
+**No behaviour change.** Pure refactor + tests-by-inspection. One PR.
+
+## Why now
+
+Phases 1–2 deleted the legacy completion system and the distribution machinery, but left:
+
+- `getWeekNumber` implemented **3×**: `src/app/helpers.ts:29`,
+  `src/lib/services/job/earningsService.ts:20`, `src/lib/services/day/dayProgressService.ts:183`
+  (two of them return `number`, one returns `[number, number]` — a latent bug).
+- List authorization spread over `authorizeListAccess` + `getUserListRole` called ad hoc in 5 route
+  files (`tasks`, `tasks/[taskId]` ×2, `tasklists/[taskListId]` ×2, `jobs`), each re-deriving the
+  same "is owner/manager/collaborator" branch.
+- Social actions (`likes`, `comments`) are polymorphic in the DB but each entity type is
+  special-cased in the route (`likes` knows `note|template|tasklist|comment`, `comments` knows
+  `note|template|list|profile|event`) — the two lists already disagree.
+- The public profile page pattern (`React.cache()` + `x-internal-fetch-secret` + `buildMetadata`)
+  exists once, in `src/app/[locale]/profile/[userName]/page.tsx`, and Phases 5 and 8 both need it.
+- Two service folders overlap: `src/lib/services/task/*` and `src/lib/services/tasklist/*`.
+
+## 3.1 Date/time kit — `src/lib/utils/date.ts`
+
+Single home for: `getWeekNumber(date): { week, year }`, `toDateKey(date): 'YYYY-MM-DD'`,
+`fromDateKey`, `startOfDayUTC`, `formatDateForLocale(date, locale)` (the formatter duplicated
+across views), `isSameDateKey`.
+
+- Delete the three `getWeekNumber` copies; re-export from `src/app/helpers.ts` with a
+  `@deprecated` note for one release so imports can migrate gradually.
+- Rule documented in the file header: **all persisted dates are UTC `YYYY-MM-DD` strings**
+  (`Job.occurrenceDate`, `Task.dtstart`, `Day.date`); `DateTime` columns are instants only.
+  Events (Phase 8) are the first true instants and carry their own `timezone`.
+
+## 3.2 Ownership kit — `src/lib/services/ownership/`
+
+`ownershipService.ts` — the one place that answers "who owns this and what may the viewer do".
+
+```ts
+export type OwnerRef = { type: 'USER' | 'ORG'; userId?: string; orgId?: string }
+export type EntityKind = 'list' | 'task' | 'job' | 'note' | 'event' | 'document' | 'profile' | 'wallet'
+export type Capability = 'view' | 'edit' | 'manage' | 'delete' | 'moderate'
+
+resolveOwner(kind, entity): OwnerRef
+getViewerRole(viewerUserId, kind, entityOrId): Promise<'OWNER'|'MANAGER'|'COLLABORATOR'|'MEMBER'|'VIEWER'|null>
+can(viewerUserId, capability, kind, entityOrId): Promise<boolean>
+assertCan(...): Promise<void>   // throws ApiError(403)
+```
+
+- Phase 3 implements `USER` ownership only, wrapping today's `getUserListRole` /
+  `authorizeListAccess` (which become thin re-exports). Phase 7 adds the `ORG` branch **in one
+  file** instead of in every route.
+- Route files replace their inline role branches with `await assertCan(user.id, 'edit', 'task', taskId)`.
+
+## 3.3 Social kit — `src/lib/services/social/`
+
+`socialService.ts` with a single registry of likeable/commentable entities:
+
+```ts
+const SOCIAL_ENTITIES = {
+  note:     { model: 'note',     visibilityField: 'visibility' },
+  template: { model: 'template', visibilityField: 'visibility' },
+  tasklist: { model: 'list',     visibilityField: 'visibility' },
+  comment:  { model: 'comment',  visibilityField: null },
+  event:    { model: 'event',    visibilityField: 'visibility' },   // enabled in Phase 8
+  task:     { model: 'task',     visibilityField: 'visibility' },   // enabled in Phase 5
+} as const
+```
+
+- `toggleLike(viewerId, entityType, entityId)`, `getLikeState(viewerId, entityType, entityId)`,
+  `getCounts(entityType, entityIds[])` (batched — kills the N+1 in feeds),
+  `listComments`, `createComment`, `deleteComment`.
+- `list`/`tasklist` alias normalised in one map (`normalizeEntityType`) so the two existing routes
+  stop disagreeing.
+- `/api/v1/likes` and `/api/v1/comments` become ~40-line routes over this service. Adding `event`
+  in Phase 8 becomes a one-line registry entry.
+
+## 3.4 Public page kit — `src/lib/public/`
+
+- `internalFetch.ts` — `cachedInternalGet<T>(path)`: the `React.cache()` +
+  `x-internal-fetch-secret` + `VERCEL_URL`/localhost base-URL logic currently inlined in
+  `profile/[userName]/page.tsx` and `magazine/[articleslug]/page.tsx`. Both are refactored onto it.
+- `slug.ts` — `buildPublicSlug(name, id)` = `slugify(name)-<last 4 of id>`, plus
+  `ensureUniqueSlug(model, slug)` retry helper. Used by list `publicUrl` (Phase 5) and event
+  `publicUrl` (Phase 8).
+- `src/app/metadata.ts` — widen the `type` union from the current set to include `'list'` and
+  `'event'` now, so Phases 5/8 only supply data.
+
+## 3.5 Service folder consolidation
+
+- Merge `src/lib/services/tasklist/*` into `src/lib/services/list/*`
+  (`listService.ts`, `listCompletionService.ts`, `helpers.ts`), keeping `index.ts` re-exports so
+  imports change in one mechanical pass. Rationale: the domain object is `List`; "tasklist" only
+  survives as an API path and a like `entityType`.
+- `src/lib/services/task/taskMigrationService.ts` — keep only the helpers still used by
+  `/api/v1/tasks/migrate`; move dead helpers out.
+- Add `src/lib/services/errors.ts`: `ApiError(status, code, message)` + `toResponse(error)` so
+  routes stop hand-rolling `NextResponse.json({ error }, { status })` in every catch block.
+
+## 3.6 API surface (unchanged contracts)
+
+No endpoint is added or removed in this phase. Response shapes must be byte-identical — this is
+the property the verification checks.
+
+## Files touched
+
+| Action | Path |
+|--------|------|
+| new | `src/lib/utils/date.ts`, `src/lib/services/ownership/{ownershipService.ts,index.ts}`, `src/lib/services/social/{socialService.ts,index.ts}`, `src/lib/public/{internalFetch.ts,slug.ts}`, `src/lib/services/errors.ts` |
+| rename | `src/lib/services/tasklist/**` → `src/lib/services/list/**` |
+| edit | `src/app/helpers.ts`, `src/lib/services/job/earningsService.ts`, `src/lib/services/day/dayProgressService.ts`, `src/app/api/v1/{likes,comments}/route.ts`, `src/app/api/v1/tasks/route.ts`, `src/app/api/v1/tasks/[taskId]/route.ts`, `src/app/api/v1/tasklists/[taskListId]/route.ts`, `src/app/api/v1/jobs/route.ts`, `src/app/[locale]/profile/[userName]/page.tsx`, `src/app/[locale]/magazine/[articleslug]/page.tsx`, `src/app/metadata.ts` |
+| docs | `src/lib/services/CLAUDE.md` (new service map), `src/app/api/v1/{likes,comments}/CLAUDE.md` |
+
+## Migrations
+
+None. Schema untouched.
+
+## Verification
+
+- `npx prisma generate && npm run build && npm run lint`.
+- Contract snapshot: before the refactor, capture responses for `GET /api/v1/tasklists`,
+  `GET /api/v1/tasks?date=&listId=`, `GET /api/v1/jobs?listId=`, `GET /api/v1/likes?...`,
+  `GET /api/v1/comments?...` into `/tmp`; after the refactor, diff them — must be empty.
+- Manual: open `/app/do`, complete a task, request+approve a job, like a note, comment on a list,
+  load a public profile page and a magazine article. All unchanged.
+- `grep -rn "function getWeekNumber" src` returns exactly one hit.

--- a/docs/plans/phase-04-media-geo-foundation.md
+++ b/docs/plans/phase-04-media-geo-foundation.md
@@ -1,0 +1,135 @@
+# Phase 4 — Media, storage & geolocation foundation
+
+**Goal:** one attachment pipeline and one place-picking pipeline used by jobs, tasks, lists, notes,
+events, event covers and A3 fliers. Replaces Phase 3 of `docs/do-rebuild-plan.md` and widens it so
+Events (Phase 8) need no new media code. One PR.
+
+Nothing of this exists today: no S3 SDK, no compression, no EXIF, no Places, no map library.
+`Document` is already the attachment model (Phase 1 activated it with `mimeType`, `kind`,
+`thumbnailUrl`, `posterUrl`, `width/height`, `location`, `taskIds`, `jobIds`, `eventIds`).
+
+## 4.1 Storage — iDrive e2 (S3-compatible)
+
+Deps: `@aws-sdk/client-s3`, `@aws-sdk/s3-request-presigner`.
+
+Env (defaults in `.env.public`, secrets in `.env.local`):
+`STORAGE_ENDPOINT`, `STORAGE_REGION`, `STORAGE_BUCKET`, `STORAGE_ACCESS_KEY_ID`,
+`STORAGE_SECRET_ACCESS_KEY`, `STORAGE_PUBLIC_BASE_URL`.
+
+- `src/lib/storage/s3.ts` — client singleton (`forcePathStyle: true`), `presignPut(key, contentType,
+  contentLength)`, `publicUrlFor(key)`, `deleteObject(key)`.
+- Key layout: `u/<userId>/<yyyy>/<mm>/<uuid>.<ext>` for user media,
+  `o/<orgId>/...` for org media (Phase 7), `ev/<eventId>/cover|flier/<uuid>.<ext>` (Phase 8).
+- **Presigned direct upload** — the browser PUTs straight to iDrive, dodging Vercel's ~4.5 MB body
+  limit. The server never proxies bytes.
+
+### Routes
+
+| Endpoint | Behaviour |
+|----------|-----------|
+| `POST /api/v1/attachments/presign` | auth; validate extension allowlist + declared size ≤ cap → `{ uploadUrl, key, publicUrl, expiresIn }`. Cap is per-`kind` (see 4.3). |
+| `POST /api/v1/attachments` | auth; `{ key, fileName, fileFormat, fileSize, mimeType, kind, width?, height?, duration?, location?, entityType, entityId, role? }` → verifies the key belongs to the caller's prefix, then **inspects the object's real bytes**: a ranged GET of the first 4 KB is checked against a magic-byte table (`file-type`) and must match the declared `kind`/extension; the HEAD size must be within cap. Only then is the `Document` created and linked, after `assertCan(user, 'edit', entityType, entityId)`. `role` distinguishes `cover` / `flier` / `evidence` / `inline`. Mismatch → the object is deleted and 400 returned. |
+| `DELETE /api/v1/attachments/[documentId]` | auth + ownership; unlink, delete object, delete row. |
+
+Server-side re-validation after upload is what makes the client cap non-authoritative.
+
+**Serving safety**: `STORAGE_PUBLIC_BASE_URL` points at a media-only origin (separate host/CDN,
+never the app domain), objects are stored with the sniffed `Content-Type`,
+`X-Content-Type-Options: nosniff` and, for anything not in the image/video allowlist,
+`Content-Disposition: attachment`. A disguised HTML/SVG payload therefore cannot execute in our
+origin. SVG is **not** in the allowlist.
+
+**EXIF location consent**: GPS extracted from a photo pre-fills the location field but is
+**opt-in per upload** — the picker shows "attach location from this photo?" unchecked by default
+for anything destined for a public surface (public tasks, events, public notes). Metadata is
+stripped from the re-encoded output, so nothing leaks implicitly.
+
+## 4.2 Client compression — `src/lib/utils/mediaCompression.ts`
+
+Deps: `heic2any`, `exifr`, `@ffmpeg/ffmpeg` (core loaded from CDN via `toBlobURL`, never bundled).
+
+- **Images**: read EXIF with `exifr` **before** re-encode (GPS → `location`, orientation honoured);
+  HEIC/HEIF → `heic2any`; canvas re-encode to WebP (JPEG fallback) q0.8, longest edge ≤ 2048 px
+  (≤ 4096 px for `role: 'flier'`, see 4.4); loop-reduce quality until ≤ cap.
+- **Video**: `ffmpeg.wasm` → H.264 720p 30 fps MP4 + extracted poster frame (uploaded as a second
+  object, stored in `Document.posterUrl`).
+- Allowlist: images `heic heif jpg jpeg png webp gif`; video `mp4 mov webm`; documents `pdf`.
+- Caps (post-compression): image 5 MB, flier 8 MB, video 25 MB, pdf 10 MB. Enforced client-side for
+  UX and server-side (`presign` + post-upload HEAD) for truth.
+
+## 4.3 Components
+
+- `src/components/attachmentPicker.tsx` — file input + drag/drop, previews, per-file compression
+  progress, per-file location chip (EXIF-filled, editable via PlacePicker), remove, reorder.
+  Props: `{ entityType, entityId?, role, max, accept, onChange }`. When `entityId` is absent
+  (create-flows) it returns pending descriptors that the parent commits after the entity exists.
+- `src/components/imageCropper.tsx` — thin wrapper for fixed-aspect crops: `16:9` (event cover),
+  `1:√2` (A3 flier), `1:1` (avatars). Keeps Phase 8 free of layout hacks.
+
+## 4.4 Event media presets (consumed in Phase 8, built here)
+
+| Preset | Aspect | Target | Stored on |
+|--------|--------|--------|-----------|
+| `cover` | 16:9 | ≤ 2560×1440 WebP | `Event.coverDocumentId` |
+| `flier` | A3 portrait, 1:1.414 | ≤ 2480×3508 (A3 @ 300 dpi long edge capped to 3508) WebP + PDF passthrough allowed | `Event.flierDocumentId` |
+| `thumb` | 16:9 | 640 px, generated client-side | `Document.thumbnailUrl` |
+
+## 4.5 Geolocation — our own UI over Google Places
+
+Env: `GOOGLE_PLACES_API_KEY` (**server-only**, never `NEXT_PUBLIC_`).
+
+- `GET /api/v1/places/autocomplete?input=&sessionToken=` — server proxy, 5 results, in-memory LRU
+  (5 min) to control quota; rate-limited per user.
+- `GET /api/v1/places/details?placeId=&sessionToken=` → `{ lat, lng, placeId, name, address }`.
+- `src/components/placePicker.tsx` — own input + debounced (300 ms) result list in a shadcn
+  Popover, keyboard navigable, "use my current location" (browser geolocation → reverse geocode),
+  and a manual lat/lng escape hatch. Emits the canonical `location` JSON shape used everywhere:
+  `{ lat, lng, placeId?, name?, address? }`.
+- `src/components/locationMap.tsx` — static-first map: renders the Google Static Maps image
+  (proxied through `GET /api/v1/places/staticmap?lat=&lng=&zoom=` so the key stays server-side)
+  with a "open in Maps" link. No map JS library, no client key, no bundle cost. Interactive
+  panning is explicitly out of scope.
+
+## 4.6 Write composer extensions — `src/components/publishNote.tsx`
+
+Today it POSTs `{ content, visibility, date, recipientId }` only, while `Note` already has
+`documentIds`, `listIds`, `profileIds`, `taskIds`, `eventIds`, `location`, `repostedListId`.
+
+- Add `AttachmentPicker` (≤ 4 files), `PlacePicker`, and a new
+  `src/components/entityTagPicker.tsx` (searches profiles, the user's lists, visible tasks, and
+  — from Phase 8 — events; renders chips).
+- `POST /api/v1/notes` accepts and sanitises `documentIds`, `location`, `profileIds`, `listIds`,
+  `taskIds`, `eventIds`, `repostedListId`.
+- **Tag visibility rule** (server, in `visibilityService`): `resolveNoteTags(note, viewerId)` drops
+  tagged tasks the viewer can't see (public tasks → everyone; private-list tasks → members only)
+  before the note leaves the API. `noteContent.tsx`/`notesList.tsx` render chips from the resolved
+  set only.
+- Inline link previews already work (`linkPreview.tsx` + `/api/v1/link-preview`); reuse untouched —
+  this is what satisfies the "description with inline link previews" requirement in Phase 8.
+
+## Files touched
+
+| Action | Path |
+|--------|------|
+| new | `src/lib/storage/s3.ts`, `src/lib/utils/mediaCompression.ts`, `src/app/api/v1/attachments/{presign/route.ts,route.ts,[documentId]/route.ts,CLAUDE.md}`, `src/app/api/v1/places/{autocomplete,details,staticmap}/route.ts` + `CLAUDE.md`, `src/components/{attachmentPicker,imageCropper,placePicker,locationMap,entityTagPicker}.tsx` |
+| deps | `@aws-sdk/client-s3`, `@aws-sdk/s3-request-presigner`, `heic2any`, `exifr`, `@ffmpeg/ffmpeg`, `file-type` |
+| edit | `src/components/publishNote.tsx`, `src/components/noteContent.tsx`, `src/app/api/v1/notes/route.ts`, `src/lib/services/visibility/visibilityService.ts`, `package.json`, `.env.public`, `src/app/api/openapi.yaml` |
+
+## Migrations
+
+None (Phase 1's `0019-convert-task-documents.js` already normalised `Document`).
+
+## Verification
+
+- Upload a 12 MB HEIC → converted, ≤ 5 MB, renders; EXIF GPS is offered, not auto-attached, and
+  attaches to the job's `location` only when the user opts in.
+- Rename `payload.html` to `photo.jpg` and upload → magic-byte check rejects it, object deleted, 400.
+- Fetch an uploaded file → served from the media origin with `nosniff` and a sniffed content type.
+- Upload a 60 MB `.mov` → compressed ≤ 25 MB, poster frame stored and shown.
+- A file above cap after compression is rejected client-side **and** by `presign`.
+- Tamper test: call `POST /api/v1/attachments` with a `key` under another user's prefix → 403.
+- PlacePicker search returns results; picking one stores the 5-field JSON; `locationMap` renders
+  and the Places key never appears in the client bundle
+  (`grep -r GOOGLE_PLACES .next/static` → no hits).
+- Write a note with 2 photos, a place, a profile tag and a private-list task tag; a non-member
+  viewer sees the note without the private task chip.

--- a/docs/plans/phase-05-public-lists-job-board.md
+++ b/docs/plans/phase-05-public-lists-job-board.md
@@ -1,0 +1,130 @@
+# Phase 5 — Public list profiles + job board
+
+**Goal:** a `List` gets a public face that shows *only what it chooses to show*, and its public
+tasks become job posts people can apply to. Extends Phase 4 of `docs/do-rebuild-plan.md` with the
+job-board requirement.
+
+Depends on: Phase 3 (ownership/social/slug/public-page kits), Phase 4 (media + places).
+
+## 5.1 Model
+
+`List` already has `bio`, `profilePhoto`, `links Json?`, `publicUrl String? @unique`,
+`visibility`, and `requests ListRequest[]` (Phase 1). Add:
+
+```prisma
+model List {
+  // ...
+  publicTagline   String?
+  publicVisible   Boolean  @default(false)  // explicit publish switch, independent of `visibility`
+  coverDocumentId String?  @db.ObjectId
+  location        Json?                     // org/venue location for the board
+  jobBoardEnabled Boolean  @default(false)
+  @@index([publicVisible])
+}
+```
+
+`List.publicUrl` is already `String? @unique` from Phase 1. **Prisma-on-Mongo cannot declare a
+sparse/partial unique index**, so more than one row with `publicUrl: null` would violate it. This
+phase therefore makes the slug **always present**: migration `0020` backfills every existing list
+and `POST /api/v1/tasklists` generates one at creation, so the column is effectively non-null.
+Privacy comes from `publicVisible`, never from the absence of a slug. (Keeping the field optional
+in the schema avoids a breaking `prisma generate` on partially-migrated data; a follow-up flips it
+to required once the backfill is verified.)
+
+`Task` — job-post fields (a task is a job post when `visibility = PUBLIC` **and** the list has
+`jobBoardEnabled`):
+
+```prisma
+model Task {
+  // ...
+  jobDescription String?    // long form, markdown + inline link previews
+  requirements   String?
+  openings       Int?       @default(1)
+  applyBy        String?    // YYYY-MM-DD
+  applications   TaskApplication[]
+  @@index([visibility])
+}
+
+model TaskApplication {
+  id         String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  status     String   @default("PENDING")   // PENDING | SHORTLISTED | ACCEPTED | DECLINED | WITHDRAWN
+  message    String?
+  documentIds String[] @default([]) @db.ObjectId   // CV / portfolio via Phase 4
+  taskId     String   @db.ObjectId
+  task       Task     @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  listId     String   @db.ObjectId
+  userId     String   @db.ObjectId
+  user       User     @relation("TaskApplications", fields: [userId], references: [id], onDelete: Cascade)
+  @@unique([taskId, userId])
+  @@index([listId, status])
+}
+```
+
+Accepting an application adds the applicant to `Task.candidateIds` **and** creates the
+`ListRequest`-equivalent membership (`UserReference{ userId, role: 'COLLABORATOR' }` on the list),
+so the existing job/earnings flow works unchanged from there.
+
+**Privacy rule (hard requirement):** the public payload is built by an allowlist projection in the
+service, never by deleting fields from a full record. Private tasks, budgets, earnings, member
+financials, jobs and history never enter the public serializer.
+
+## 5.2 API
+
+| Endpoint | Notes |
+|----------|-------|
+| `GET /api/v1/tasklists/public/[publicUrl]` | Unauthenticated. Returns `{ name, publicTagline, bio, profilePhoto, cover, links, location, ownerProfile, collaboratorProfiles, publicTasks[], likeCount, viewer: { isLiked, isMember, hasPendingRequest, hasApplied } }`. `publicTasks` carry `{ id, name, jobDescription, requirements, openings, applyBy, premium (display only), area, categories, location }`. |
+| `GET /api/v1/tasklists/public?cursor=&q=&area=&category=` | Job-board discovery feed across all published lists. Cursor pagination, `visibility: PUBLIC` + `publicVisible: true` only. |
+| `PUT /api/v1/tasklists/[id]` | Extended with the public-profile fields + `jobBoardEnabled`; generates `publicUrl` via `buildPublicSlug` on first publish. |
+| `POST /api/v1/tasks/[taskId]/apply` | `{ message?, documentIds? }` → `TaskApplication` PENDING. Rejects if the task isn't public, applications closed (`applyBy` past) or `openings` filled. |
+| `GET /api/v1/tasks/[taskId]/applications` | Owner/manager only. |
+| `POST /api/v1/tasks/[taskId]/applications/[applicationId]` | `{ status }` — accept/shortlist/decline; ACCEPTED adds candidate + list membership. |
+| `POST /api/v1/tasklists/[id]/candidate` | Existing `ListRequest` flow (general "join this list" ask, separate from applying to a specific task). |
+| `POST /api/v1/tasklists/[id]/requests/[requestId]` | Approve/decline (owner/manager). |
+| `POST /api/v1/likes` | `entityType: 'tasklist'` — already supported, now via the Phase 3 social kit. |
+
+## 5.3 Pages
+
+- `src/app/[locale]/list/[publicUrl]/page.tsx` — server component using
+  `cachedInternalGet` + `buildMetadata(..., type: 'list')` (OG image = cover or `profilePhoto`,
+  description = `publicTagline || bio`), `notFound()` on miss. Bot/English metadata handled by the
+  existing middleware cookie logic.
+- `src/views/list/publicListView.tsx` — hero (cover, photo, name, tagline, links, location map from
+  Phase 4), About, **Open positions** grid of public tasks, Support/Like, Donate stub, Repost,
+  Request to join.
+- `src/app/[locale]/list/[publicUrl]/jobs/[taskId]/page.tsx` — single job post page (own metadata,
+  apply button, `ApplyDialog` with message + attachments).
+- `src/app/[locale]/app/be/jobs/page.tsx` — logged-in job board discovery (filters by area,
+  category, location, text) feeding off `GET /api/v1/tasklists/public`.
+- `src/app/sitemap.ts` — include published lists and their public job posts.
+
+Client islands only for the action buttons; the page body stays a server component for SEO.
+
+## 5.4 List settings UI
+
+`addListForm.tsx` (rebuilt to ~250 lines in Phase 2) gains a collapsed **Public profile** section:
+publish switch, tagline, bio, cover (Phase 4 picker, 16:9), links repeater, location, job-board
+switch, and the read-only `publicUrl` with a copy button. Pending `ListRequest`s and
+`TaskApplication`s get a review panel here.
+
+`addTaskForm.tsx` gains a **Publish as job** section (visibility PUBLIC + description,
+requirements, openings, applyBy) shown only when the list has `jobBoardEnabled`.
+
+## Migrations
+
+- `0020-backfill-list-publicurl.js` — `buildPublicSlug(name, id)` for every list, uniqueness retry,
+  `publicVisible: false` for all existing lists (opt-in publishing, no accidental exposure).
+
+## i18n
+
+New key groups: `list.public.*`, `jobs.board.*`, `jobs.apply.*`, `jobs.applicationStatus.*`.
+
+## Verification
+
+- Publish a list → `/en/list/<slug>` renders; `curl` shows OG tags; bot cookie yields English.
+- A private task never appears in the public payload (assert on the raw JSON, not the DOM).
+- Apply to a job as another user → owner sees the application, accepts → applicant becomes a
+  collaborator and can request a job on that task through the existing Do flow.
+- Applying twice → 409; applying after `applyBy` → 400; applying to a task in an unpublished list → 404.
+- `publicVisible: false` list returns 404 on the public route even with a valid slug.

--- a/docs/plans/phase-06-dpip-ledger.md
+++ b/docs/plans/phase-06-dpip-ledger.md
@@ -1,0 +1,193 @@
+# Phase 6 — DPIP ledger & wallets
+
+**Goal:** DPIP becomes a spendable, auditable platform balance. Off-chain ledger is the source of
+truth; Kaleido becomes an optional mirror. Prerequisite for ticketing (9) and allowances (11).
+
+Today: `Wallet` has no balance (balance is fetched live from Kaleido `balanceOf`), wallets are
+created manually (max 5, `POST /api/v1/wallet`), and `POST /api/v1/wallet/transfer` writes a
+`Transaction { status: 'pending' }` that nothing ever settles.
+
+## 6.1 Model
+
+```prisma
+model Wallet {
+  // existing: name, address, visibility, userId, budgetIds, noteIds, documentIds
+  balance         Int      @default(0)      // authoritative spendable DPIP, in MINOR UNITS (1 DPIP = 100)
+  pendingBalance  Int      @default(0)      // held by open reservations/escrow, minor units
+  currency        String   @default("DPIP")
+  kind            String   @default("USER") // USER | ORG | EVENT | ESCROW | SYSTEM
+  isDefault       Boolean  @default(false)
+  ownerType       String   @default("USER") // USER | ORG   (Phase 7 populates ORG)
+  orgId           String?  @db.ObjectId
+  eventId         String?  @db.ObjectId     // Phase 8: event proceeds wallet
+  onChainSyncedAt DateTime?
+  frozen          Boolean  @default(false)
+  entries         LedgerEntry[]
+  @@index([ownerType, orgId])
+  @@index([userId, isDefault])
+}
+
+model LedgerEntry {
+  id            String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt     DateTime @default(now())
+  transactionId String   @db.ObjectId
+  transaction   Transaction @relation(fields: [transactionId], references: [id], onDelete: Cascade)
+  walletId      String   @db.ObjectId
+  wallet        Wallet   @relation(fields: [walletId], references: [id], onDelete: Cascade)
+  direction     String   // DEBIT | CREDIT
+  amount        Int      // always positive, minor units
+  balanceAfter  Int
+  currency      String   @default("DPIP")
+  @@index([walletId, createdAt])
+  @@index([transactionId])
+}
+
+model Transaction {
+  // existing: amount (legacy Float, retained), type, status, fromAddress, toAddress, userId, walletId, ...
+  amountMinor   Int?                      // new authoritative amount; legacy `amount` kept for old rows
+  reference     String   @unique          // idempotency key
+  kind          String                    // TRANSFER | TICKET_PURCHASE | TICKET_RESERVATION |
+                                          // TICKET_BALANCE | REFUND | ALLOWANCE_GRANT | PAYOUT | ADJUSTMENT
+  fromWalletId  String?  @db.ObjectId
+  toWalletId    String?  @db.ObjectId
+  eventId       String?  @db.ObjectId
+  ticketId      String?  @db.ObjectId
+  metadata      Json?
+  settledAt     DateTime?
+  failureReason String?
+  onChainTxHash String?
+  entries       LedgerEntry[]
+  @@index([kind, status])
+  @@index([fromWalletId]) @@index([toWalletId])
+}
+```
+
+`Transaction.status` is normalised to `PENDING | SETTLED | FAILED | REVERSED` (existing lowercase
+`'pending'` rows migrated).
+
+Every value movement produces exactly **two** `LedgerEntry` rows (one DEBIT, one CREDIT) whose
+amounts sum to zero across the system. `SUM(DEBIT) - SUM(CREDIT)` over all entries is the ledger's
+invariant and is asserted by the reconciliation job.
+
+## 6.2 Money handling — `src/lib/utils/money.ts`
+
+`toMinor(dpip): number` (×100, rounded — boundary parsing only), `fromMinor(minor): number`,
+`formatDpip(minor, locale)`, `assertPositiveMinor(minor)`. **Every persisted monetary value and
+every arithmetic operation is in integer minor units.** Floats exist only in JSON at the edge and
+in locale formatting. `Int` tops out at ~21.4 M DPIP per row, which is far above any expected
+value; if that ever changes, the fields move to `BigInt` (also supported by Prisma-on-Mongo) —
+noted here so the decision is deliberate.
+
+## 6.3 Ledger service — `src/lib/services/ledger/ledgerService.ts`
+
+```ts
+transfer({ fromWalletId, toWalletId, amountMinor, kind, reference, metadata, actorUserId })
+hold({ walletId, amountMinor, reference, ... })  // balance → pendingBalance (reservations)
+capture({ reference, amountMinor })              // pendingBalance → transfer to destination
+release({ reference })                           // pendingBalance → balance (expiry/cancel)
+credit({ walletId, amountMinor, kind, reference })// system-issued (allowances)
+getBalance(walletId) / getStatement(walletId, { cursor, kind })
+```
+
+**Atomicity: a single interactive transaction, not compensation.** MongoDB Atlas runs as a replica
+set, so Prisma 6's interactive `prisma.$transaction(async (tx) => { … })` gives real multi-document
+atomicity. The whole movement — debit, credit, both ledger entries, transaction status — commits or
+aborts together. A `DATABASE_URL` without a replica set is a **deployment error**, asserted at boot
+(`assertTransactionalDatabase()`), because the ledger's correctness depends on it.
+
+```
+transfer(...):
+  existing = await tx.transaction.findUnique({ where: { reference } })
+  if (existing?.status === 'SETTLED') return existing            // idempotent replay
+  await prisma.$transaction(async (tx) => {
+    1. tx.transaction.create({ reference, status: 'PENDING', ... })   // P2002 ⇒ concurrent replay
+    2. const debited = await tx.wallet.updateMany({
+         where: { id: fromWalletId, frozen: false, balance: { gte: amountMinor } },
+         data:  { balance: { decrement: amountMinor } } })
+       if (debited.count !== 1) throw new ApiError(400, 'INSUFFICIENT_FUNDS')
+    3. tx.wallet.update({ where: { id: toWalletId }, data: { balance: { increment: amountMinor } } })
+    4. tx.ledgerEntry.createMany([ DEBIT(from), CREDIT(to) ])         // balanceAfter read inside tx
+    5. tx.transaction.update({ status: 'SETTLED', settledAt: now })
+  }, { maxWait: 5000, timeout: 15000 })
+```
+
+Points that matter:
+
+- The **conditional `updateMany` with `{ balance: { gte } }`** is still how the debit is expressed —
+  it is a compare-and-set, so two concurrent transfers can never both pass the balance check. Naive
+  read-then-write is forbidden.
+- Insufficient funds throws **inside** the transaction, so the `PENDING` row is rolled back too;
+  the caller gets a clean 400 with no residue. (A separate `FAILED` audit row is written outside
+  the transaction when we want the attempt recorded.)
+- `credit()` from the treasury skips the balance guard: `SYSTEM:treasury` is the issuer and is
+  allowed to go negative — its negative balance is precisely the amount of DPIP in circulation.
+- **Recovery sweep** (`/api/cron/ledger-reconcile`, hourly): any `PENDING` transaction older than
+  15 minutes is an abandoned/crashed attempt; it is marked `FAILED` after verifying it has zero
+  ledger entries. Transactions with exactly one entry are impossible under the transactional design
+  and are alarmed as data corruption rather than auto-repaired.
+- Invariant check in the same job: `Σ DEBIT − Σ CREDIT = 0`, and every wallet's `balance` equals the
+  `balanceAfter` of its newest entry. Divergence pages the team; it never silently rewrites balances.
+
+## 6.4 Wallet lifecycle
+
+- **Default wallet at signup**: `POST /api/v1/auth` (`user.created`) creates the internal `User`,
+  `Profile` **and** a default `Wallet { kind: 'USER', isDefault: true, balance: 0 }`. Idempotent
+  (checks for an existing default first — Clerk retries webhooks).
+- `getOrCreateDefaultWallet(userId)` in the wallet service is called defensively by anything that
+  needs to move money, so pre-existing users self-heal on first use.
+- Kaleido `generateWallet()` becomes **lazy and non-blocking**: the DB wallet exists immediately
+  with `address: null`; the address is provisioned on demand (first on-chain-facing action) or by
+  the reconcile cron. A Kaleido outage can no longer block signup or a purchase.
+- Keep the 5-wallet cap for user-created extra wallets; system wallets (`EVENT`, `ESCROW`,
+  `SYSTEM`) don't count.
+
+### System wallets
+
+Seeded once by migration: `SYSTEM:treasury` (source of allowance grants, may go negative — it's the
+issuer) and `SYSTEM:escrow` (holds ticket funds until an event settles).
+
+## 6.5 API
+
+| Endpoint | Notes |
+|----------|-------|
+| `GET /api/v1/wallet` | Now returns DB `balance`/`pendingBalance` first; on-chain balance moves to an optional `?includeOnChain=true` (never blocks the response). |
+| `POST /api/v1/wallet/transfer` | Rewritten over `ledgerService.transfer`. Body `{ toAddress \| toWalletId \| toUsername, amount, note?, reference? }`. Server generates `reference` if absent. Returns the settled transaction + new balance. |
+| `GET /api/v1/wallet/[walletId]/statement?cursor=` | New — paginated ledger entries with running balance. |
+| `GET /api/v1/wallet/resolve?username=` | Resolve a recipient's default wallet for the transfer UI. |
+| `POST /api/v1/wallet/[walletId]/sync-onchain` | Explicit, manual Kaleido mirror (admin/opt-in). |
+
+## 6.6 UI
+
+- `src/components/tokenTransfer.tsx` — recipient by username or address, amount with balance-aware
+  validation, confirm step, optimistic SWR update, error surface for insufficient funds.
+- `src/components/walletBalanceCard.tsx` — balance, pending, statement list (new).
+- `src/views/invest/investView.tsx` — surfaces the statement; NFT/Kaleido panels stay as-is.
+
+## Migrations
+
+- `0021-create-default-wallets.js` — one default wallet per existing user (skips users who already
+  have one; marks the oldest as `isDefault`), `balance: 0` in minor units.
+- `0022-normalize-transactions.js` — lowercase `status`/`type` → the new enums-as-strings, derive
+  `kind` (`'transfer'` → `TRANSFER`), set `amountMinor = round(amount × 100)`, backfill `reference`
+  (`legacy:<_id>`), resolve `fromWalletId`/`toWalletId` from addresses where possible; unresolvable
+  rows → `status: FAILED`, `failureReason: 'legacy-unsettled'` (they never moved value: no ledger
+  entries are written).
+- `0023-seed-system-wallets.js` — treasury + escrow.
+- `0024-backfill-ledger-entries.js` — for `SETTLED` legacy transfers only, write the paired entries
+  and set `balanceAfter` by replaying in `createdAt` order. Balances start at 0; any Kaleido
+  holdings are *not* auto-credited (that is a deliberate, separately approved treasury action).
+
+## Verification
+
+- Transfer 10 DPIP A→B: both balances change, 2 ledger entries, `SETTLED`, statement shows it.
+- Replay the same `reference` → returns the same transaction, no double movement.
+- Transfer more than the balance → 400, balances untouched, **no** `PENDING` residue.
+- 50 concurrent transfers of 1 DPIP from a wallet holding 10 → exactly 10 succeed
+  (script it; this is the overspend test).
+- Kill the process mid-transfer (fault injection between debit and credit) → after restart the
+  balances are unchanged (transaction aborted) and the reconcile job reports nothing to fix.
+- Boot with a non-replica-set `DATABASE_URL` → `assertTransactionalDatabase()` fails loudly.
+- Sum of all `LedgerEntry` DEBIT − CREDIT = 0; each wallet's `balance` equals its last
+  `balanceAfter`; treasury's negative balance equals total DPIP in circulation.
+- New signup (Clerk test webhook, delivered twice) → exactly one default wallet.
+- Kaleido env unset → signup, transfer and wallet listing still work.

--- a/docs/plans/phase-07-organizations.md
+++ b/docs/plans/phase-07-organizations.md
@@ -1,0 +1,147 @@
+# Phase 7 — Organizations
+
+**Goal:** organizations become first-class owners — org profiles, org lists (and therefore org job
+boards), org wallets and, in Phase 8, org events. Clerk Organizations stay the identity and
+membership source of truth; Prisma gets a mirror so we can join and index locally.
+
+Today: `ChatOrgMembership { clerkOrgId, userId, role }` + Clerk orgs power chat only. `Profile` and
+`List` are strictly user-scoped. `useFeatureFlag` treats membership of the Clerk org `dupip` as
+premium.
+
+## 7.1 Model
+
+```prisma
+model Organization {
+  id          String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  clerkOrgId  String   @unique
+  slug        String   @unique             // always present (no sparse unique on Mongo)
+  name        String
+  imageUrl    String?
+  bio         String?
+  links       Json?
+  location    Json?
+  publicVisible Boolean @default(false)
+  verified    Boolean  @default(false)
+  status      String   @default("ACTIVE")  // ACTIVE | ORPHANED (deleted in Clerk) | ARCHIVED
+  deletedAt   DateTime?
+  createdByUserId String @db.ObjectId
+  members     OrgMembership[]
+  lists       List[]
+  wallets     Wallet[]
+  @@index([publicVisible])
+  @@index([status])
+}
+
+model OrgMembership {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  orgId     String   @db.ObjectId
+  org       Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  userId    String   @db.ObjectId
+  user      User     @relation("OrgMemberships", fields: [userId], references: [id], onDelete: Cascade)
+  role      String   @default("MEMBER")  // OWNER | ADMIN | MANAGER | MEMBER | STAFF
+  clerkOrgId String
+  @@unique([orgId, userId])
+  @@index([userId])
+}
+```
+
+Polymorphic owner added to `List` and `Wallet` (and `Event` in Phase 8, which declares the
+`Organization.events` inverse there — not here, since that model doesn't exist yet):
+
+```prisma
+ownerType String  @default("USER")  // USER | ORG
+orgId     String? @db.ObjectId
+org       Organization? @relation(fields: [orgId], references: [id])
+@@index([ownerType, orgId])
+```
+
+**`Profile` is deliberately untouched.** `Profile.userId` is required and `@unique`, so an org
+cannot own a `Profile` without breaking the personal-profile invariant. **The `Organization` row
+*is* the org's public profile** — it carries `slug`, `bio`, `links`, `location`, `imageUrl` — and
+`/org/[slug]` renders from it. No `Profile` row is created for orgs, and nothing in the feed
+assumes one (org-authored content resolves its display identity through `ownerType`).
+
+`userId` stays required on owned rows and means **creator/steward** even for org-owned data, so
+existing queries keep working and audit trails survive a membership change.
+
+`ChatOrgMembership` is **not** deleted in this phase: `OrgMembership` becomes the general model and
+a migration copies rows across; chat continues reading its own model until a follow-up removes it.
+Both are kept in sync by the same webhook handler.
+
+`STAFF` is the role used by Phase 10's door scanner.
+
+## 7.2 Clerk sync
+
+- `POST /api/v1/webhooks/clerk` (extend the existing `/api/v1/auth` handler or split it — split
+  recommended, keeping signature verification shared) handles
+  `organization.created|updated|deleted` and
+  `organizationMembership.created|updated|deleted` → upserts `Organization` / `OrgMembership`.
+  Idempotent upserts keyed on `clerkOrgId` / `(clerkOrgId, userId)`.
+- `syncOrganization(clerkOrgId)` in `src/lib/services/org/orgService.ts` is a pull-based repair used
+  on demand when a request references an org we haven't mirrored yet (webhook loss tolerance).
+- Org creation via `POST /api/v1/chat/orgs` is generalised to `POST /api/v1/orgs` (chat keeps a
+  thin alias): creates the Clerk org, the mirror, the `OWNER` membership, the default `general`
+  chat channel and the org's default wallet (`kind: 'ORG'`, Phase 6).
+
+## 7.3 Ownership kit gains the ORG branch
+
+Phase 3's `ownershipService` is extended in one place:
+
+```
+getViewerRole(viewer, kind, entity):
+  entity.ownerType === 'ORG'
+    ? mapOrgRole(await orgMembership(viewer, entity.orgId))   // OWNER/ADMIN → OWNER, MANAGER → MANAGER, MEMBER → COLLABORATOR, STAFF → STAFF
+    : existing user/UserReference logic
+```
+
+Every route that already calls `assertCan` inherits org support with no edits — that is the payoff
+of Phase 3.
+
+## 7.4 API
+
+| Endpoint | Notes |
+|----------|-------|
+| `GET /api/v1/orgs` | Orgs the viewer belongs to (with role). |
+| `POST /api/v1/orgs` | Create (Clerk + mirror + wallet + channel). |
+| `GET/PUT /api/v1/orgs/[orgId]` | Detail / update public profile fields (OWNER/ADMIN). |
+| `GET /api/v1/orgs/[orgId]/members` · `POST` · `DELETE .../[userId]` | Membership management, proxied to Clerk then mirrored. |
+| `GET /api/v1/orgs/public/[slug]` | Public org profile: bio, links, location, published lists, upcoming events (Phase 8), like count. |
+| `POST /api/v1/tasklists` | Accepts `ownerType: 'ORG', orgId` — requires MANAGER+ in that org. |
+| `GET /api/v1/tasklists?scope=me\|org:<id>\|all` | Scoped listing. |
+
+## 7.5 UI
+
+- **Org switcher** in the app shell: reuse Clerk's `useOrganizationList`; selecting an org sets an
+  `activeOrgId` in `GlobalContext` + a cookie, which scopes the Do list picker, the Be composer's
+  "post as", and the event creation form (Phase 8).
+- `src/app/[locale]/app/be/organizations/page.tsx` — currently a disabled tab; becomes the org
+  directory + "create organization" + per-org card (members, lists, events).
+- `src/app/[locale]/org/[slug]/page.tsx` — public org profile, built on the Phase 3 public-page kit
+  with `buildMetadata(..., type: 'org')`.
+- `addListForm.tsx` — an owner selector (Me / each org where the viewer is MANAGER+) shown only when
+  the user has org memberships.
+
+## Migrations
+
+- `0025-mirror-clerk-organizations.js` — pull all Clerk orgs + memberships (paginated), upsert
+  `Organization`/`OrgMembership`, copy from `ChatOrgMembership` where Clerk is unreachable, seed
+  slugs and default org wallets.
+- `0026-backfill-owner-type.js` — set `ownerType: 'USER'` on every existing `List` and `Wallet`
+  (defaults cover new rows; this normalises old ones for index use).
+
+## Verification
+
+- Create an org in-app → Clerk org exists, mirror row exists, creator is OWNER, org wallet created,
+  `general` channel created.
+- Add/remove a member in the Clerk dashboard → webhook updates `OrgMembership` within seconds;
+  re-delivering the same event changes nothing.
+- Create an org list → it appears for every MANAGER+ of the org, not in personal scope; a MEMBER can
+  view but not edit; a non-member gets 403 on edit and 404 on private read.
+- Publish an org list → the public list page shows the **org** as owner, not the creator.
+- Delete an org in Clerk → the mirror is marked `status: 'ORPHANED'` with `deletedAt` set; its lists
+  and events are retained and readable by their steward, no route 500s, and the public org page
+  404s.

--- a/docs/plans/phase-08-events-core.md
+++ b/docs/plans/phase-08-events-core.md
@@ -1,0 +1,202 @@
+# Phase 8 — Events core
+
+**Goal:** a real `Event` entity with pages, discovery at `/app/be/events`, many-to-many links to
+lists, media, location/map, social actions and notes-as-comments. Ticketing is deliberately **not**
+here — it lands in Phase 9 on top of this.
+
+Depends on: Phase 3 (social/public-page kits), Phase 4 (media + places + map), Phase 7 (org owner),
+Phase 5 (public list surface it links to).
+
+## 8.1 Naming collision — resolve first
+
+The current `Event` model is a *life event* (name + quality, referenced from tasks via
+`EventReference`, from notes via `noteIds`, from `Day.eventIds`, and from `Comment.eventId`;
+`GET /api/v1/events` literally returns `lifeEvents`). It is unrelated to public events and must not
+be overloaded.
+
+**Resolution:** introduce `LifeEvent` (its own collection) as the home of today's data, and free
+the `Event` name for the new model.
+
+- `0027-split-life-events.js`: copy every document from the `Event` collection into `LifeEvent`
+  (preserving `_id`), then rewrite **every** inbound reference:
+  `Note.eventIds → lifeEventIds`, `Document.eventIds → lifeEventIds`, `Day.eventIds → lifeEventIds`,
+  `Comment.eventId → lifeEventId` (the real relation — `Comment.entityType` is a *secondary*
+  polymorphic field, so both the scalar relation and any `entityType: 'event'` rows are migrated),
+  `Task.events EmbeddedType[]` left as-is (it stores `{ id, name }` snapshots whose ids still
+  resolve against `LifeEvent`). Finally delete the copied source documents.
+  Idempotent: keyed on "a `LifeEvent` with this `_id` already exists".
+- Schema side: `LifeEvent` gains `comments Comment[]`, `Day.lifeEventIds`, `Note.lifeEventIds`,
+  `Document.lifeEventIds`; `Comment` gains `lifeEventId`/`lifeEvent` and keeps `eventId`/`event`
+  pointing at the **new** `Event`.
+- Routing: life events move to `/api/v1/life-events`. The legacy `/api/v1/events` path cannot both
+  redirect and host the new API, so the new events API is mounted at `/api/v1/events` **only after**
+  the legacy consumers are updated in the same PR; the redirect shim is
+  `/api/v1/events/legacy` → `/api/v1/life-events` for any out-of-tree caller, documented as
+  removed next release. `lifeEventCombobox` and task references are updated in this PR.
+
+## 8.2 Model
+
+```prisma
+model Event {
+  id            String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  // Identity
+  name          String
+  publicUrl     String   @unique           // slug-<id4>, ALWAYS generated at creation (never null:
+                                           // Prisma-on-Mongo cannot declare a sparse unique index,
+                                           // so multiple nulls would collide). Draft events simply
+                                           // 404 publicly because of `status`, not a missing slug.
+  summary       String?                    // one-liner for cards/OG
+  description   String?                   // long form; inline links rendered with LinkPreview
+  status        String   @default("DRAFT") // DRAFT | PUBLISHED | CANCELLED | COMPLETED
+  visibility    Visibility @default(PRIVATE)
+  // When
+  startsAt      DateTime
+  endsAt        DateTime?
+  timezone      String   @default("UTC")   // IANA; the event's own wall clock
+  doorsAt       DateTime?
+  // Where
+  isOnline      Boolean  @default(false)
+  onlineUrl     String?
+  location      Json?                      // { lat, lng, placeId?, name?, address? }
+  venueName     String?
+  // Media
+  coverDocumentId String? @db.ObjectId
+  flierDocumentId String? @db.ObjectId
+  // Capacity & money (used by Phase 9)
+  capacity      Int?
+  currency      String   @default("DPIP")
+  walletId      String?  @db.ObjectId      // proceeds wallet (kind: EVENT)
+  // Ownership
+  ownerType     String   @default("USER")  // USER | ORG
+  userId        String   @db.ObjectId      // creator/steward
+  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  orgId         String?  @db.ObjectId
+  org           Organization? @relation(fields: [orgId], references: [id])
+  // Relations
+  listIds       String[] @default([]) @db.ObjectId
+  lists         List[]   @relation("EventLists", fields: [listIds], references: [id])
+  rsvps         EventRsvp[]
+  staff         EventStaff[]
+  comments      Comment[]
+  noteIds       String[] @default([]) @db.ObjectId
+  documentIds   String[] @default([]) @db.ObjectId
+  categories    Category[]
+  tags          String[] @default([])
+  @@index([status, startsAt])
+  @@index([ownerType, orgId])
+  @@index([startsAt])
+}
+
+model EventRsvp {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  status    String   // INTERESTED | GOING | NOT_GOING
+  eventId   String   @db.ObjectId
+  event     Event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  userId    String   @db.ObjectId
+  user      User     @relation("EventRsvps", fields: [userId], references: [id], onDelete: Cascade)
+  @@unique([eventId, userId])
+  @@index([eventId, status])
+}
+
+model EventStaff {          // door/gate permissions (used by Phase 10)
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt DateTime @default(now())
+  eventId   String   @db.ObjectId
+  event     Event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  userId    String   @db.ObjectId
+  user      User     @relation("EventStaff", fields: [userId], references: [id], onDelete: Cascade)
+  role      String   @default("SCANNER")   // SCANNER | MANAGER
+  @@unique([eventId, userId])
+}
+```
+
+> Ticketing and attendance relations (`tiers`, `tickets`, `orders`, `soldCount`, `attendances`,
+> `ticketsEnabled`, `refundPolicy`, `allowDoorDebt`) are **not** declared here: Prisma requires both
+> sides of a relation to exist in one schema, and those models arrive in Phases 9 and 10, each of
+> which lists the exact inverse fields it adds to `Event`, `Ticket` and `User`.
+
+`List` gains the inverse: `eventIds String[] @default([]) @db.ObjectId` +
+`events Event[] @relation("EventLists", ...)` — the **many-to-many between lists and events**.
+Semantics: a linked list is the event's production backlog (its tasks/jobs are the work), and a
+published list surfaces "Events" on its public page while the event page surfaces "Get involved"
+linking to the list's job board.
+
+Also add `Note.eventIds` (the new events) — notes referencing an event are the event's
+**comment/discussion stream**, satisfying requirement 2c without a second comment system. The
+polymorphic `Comment` model stays available for short replies (`entityType: 'event'`, one line in
+the Phase 3 social registry) and likes gain `event` the same way.
+
+## 8.3 Timezone rule
+
+`startsAt`/`endsAt` are instants (UTC) plus an IANA `timezone` for display and for "is the event
+running now" checks at the door. Never store wall-clock strings. All formatting goes through
+`formatEventDate(event, locale)` in `src/lib/utils/date.ts` (Phase 3).
+
+## 8.4 API
+
+| Endpoint | Notes |
+|----------|-------|
+| `GET /api/v1/events?scope=mine\|org:<id>\|attending&status=&from=&to=&cursor=` | Authenticated management/feed listing. |
+| `POST /api/v1/events` | Create; `ownerType/orgId` honoured via `assertCan(..., 'manage', 'org', orgId)`. Generates `publicUrl`, creates the event wallet (`kind: 'EVENT'`). |
+| `GET/PUT/DELETE /api/v1/events/[eventId]` | Detail/update/cancel. DELETE on a published event with tickets → `status: CANCELLED` (soft), never a hard delete. |
+| `POST /api/v1/events/[eventId]/publish` | DRAFT → PUBLISHED with validation (name, startsAt, location-or-online, cover). |
+| `GET /api/v1/events/public?from=&to=&q=&near=&category=&cursor=` | Public discovery; `PUBLISHED` + `visibility PUBLIC` only; `near=lat,lng,radiusKm` filters by bounding box computed server-side. |
+| `GET /api/v1/events/public/[publicUrl]` | Unauthenticated event payload (allowlist projection) + `viewer` block when authenticated. |
+| `POST /api/v1/events/[eventId]/rsvp` | `{ status }` → upsert `EventRsvp`; returns fresh counts. |
+| `POST /api/v1/events/[eventId]/lists` · `DELETE .../lists/[listId]` | Link/unlink lists (m:m). |
+| `GET/POST/DELETE /api/v1/events/[eventId]/staff` | Manage door staff. |
+| `POST /api/v1/likes` | `entityType: 'event'`. |
+| `GET/POST /api/v1/comments?entityType=event` | Already polymorphic; registry entry only. |
+
+Counts (`interestedCount`, `goingCount`, `likeCount`, `commentCount`) are computed with batched
+`groupBy` in the service, never per-card in the UI.
+
+## 8.5 Pages & components
+
+- `src/app/[locale]/app/be/events/page.tsx` — replaces the disabled tab. Tabs: **Discover** (public
+  feed), **Going/Interested**, **Mine / Org**. Filters: date range, online/in-person, near me,
+  category, text. Cursor pagination.
+- `src/app/[locale]/app/be/events/[eventId]/manage/page.tsx` — organiser console: edit, publish,
+  linked lists, staff, tiers (Phase 9), attendance (Phase 10).
+- `src/app/[locale]/event/[publicUrl]/page.tsx` — **public event page**, server component,
+  `buildMetadata(..., type: 'event')` (OG image = cover, description = summary), JSON-LD `Event`
+  structured data for search/social. Sections: cover, title/date/venue, action bar (Like ·
+  Interested · Going · Buy/Reserve placeholder until Phase 9), description with inline link
+  previews, flier (A3, click to open full size), map (`locationMap`) or online badge, host
+  (user or org) card, linked lists / "Get involved" job board links, discussion (notes + comments).
+- `src/components/eventCard.tsx`, `src/views/be/eventsView.tsx`,
+  `src/views/forms/addEventForm.tsx` (name, summary, description, date/time + timezone, online
+  toggle/URL, PlacePicker, cover + flier pickers with the Phase 4 crop presets, capacity,
+  visibility, linked lists, owner selector).
+- `beView.tsx` activity feed gains event cards (published events from friends/orgs you follow),
+  merged into the existing notes+templates merge.
+- `src/app/sitemap.ts` — published public events.
+
+## Migrations
+
+- `0027-split-life-events.js` (see 8.1) — includes `Day.eventIds`, `Comment.eventId` and the
+  `Note`/`Document` arrays.
+- `0028-backfill-event-slugs.js` — no existing rows to slug (the collection is new), but the script
+  exists so a re-run after a failed publish repairs any event lacking a `publicUrl`.
+
+## i18n
+
+`events.*` (list/discover/filters), `events.form.*`, `events.rsvp.*`, `events.public.*`,
+`events.manage.*`.
+
+## Verification
+
+- Life-event data survives the split: task→event references, `Day.eventIds`, note/document arrays
+  and existing event comments all still resolve; `/api/v1/life-events` returns the same rows.
+- Create a draft event → not visible publicly; publish → visible at `/en/event/<slug>` with correct
+  OG tags and JSON-LD (validate with a rich-results checker).
+- Timezone: an event created for 20:00 in `America/Sao_Paulo` shows 20:00 there and the correct
+  converted local time for a viewer in `Europe/Lisbon`.
+- Interested/Going toggles are idempotent and counts stay correct under double-click.
+- Link a list → the event page links to its job board and the public list page lists the event.
+- Post a note tagging the event → it appears in the event discussion; a private note does not.
+- Org-owned event: only MANAGER+ of the org can edit; the public page credits the org.

--- a/docs/plans/phase-09-ticketing.md
+++ b/docs/plans/phase-09-ticketing.md
@@ -1,0 +1,216 @@
+# Phase 9 — Ticketing & checkout (DPIP)
+
+**Goal:** sell and reserve seats in DPIP, with tiered pricing, promo/early-bird windows, bundles,
+and deposit-now / pay-rest-at-the-door. Money moves only through the Phase 6 ledger.
+
+Depends on: Phase 6 (ledger), Phase 8 (events).
+
+## 9.1 Model
+
+```prisma
+model TicketTier {
+  id            String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  eventId       String   @db.ObjectId
+  event         Event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  name          String                     // "Early bird", "Promo 3-pack", "Door"
+  description   String?
+  kind          String   @default("PAID")  // PAID | FREE | DONATION
+  unitPrice     Int      @default(0)       // MINOR UNITS, price of ONE issued ticket
+  bundleSize    Int      @default(1)       // tickets issued per purchased unit (promo bundles)
+  bundlePrice   Int?                       // MINOR UNITS, total for one bundle; defaults to unitPrice × bundleSize
+  depositPerTicket Int?                    // MINOR UNITS due now; remainder collected at the door
+  salesStartAt  DateTime?
+  salesEndAt    DateTime?                  // "10 DPIP until Aug 1"
+  capacity      Int?                       // in TICKETS (null = only bounded by Event.capacity)
+  sold          Int      @default(0)       // tickets issued from this tier (reserved + paid)
+  maxPerUser    Int?     @default(10)
+  minQuantity   Int      @default(1)
+  visibility    String   @default("PUBLIC")  // PUBLIC | HIDDEN (unlocked by code)
+  accessCode    String?
+  sortOrder     Int      @default(0)
+  active        Boolean  @default(true)
+  tickets       Ticket[]
+  @@index([eventId, active])
+}
+
+model TicketOrder {
+  id            String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  reference     String   @unique          // client-supplied checkout key; shared with the Transaction
+  status        String   @default("PENDING") // PENDING | PAID | RESERVED | CANCELLED | REFUNDED | EXPIRED
+  eventId       String   @db.ObjectId
+  buyerUserId   String   @db.ObjectId
+  buyer         User     @relation("TicketOrders", fields: [buyerUserId], references: [id], onDelete: Cascade)
+  tierId        String   @db.ObjectId
+  quantity      Int      @default(1)      // bundles purchased
+  ticketCount   Int      @default(1)      // quantity × bundleSize — the number of Ticket rows
+  subtotal      Int                       // MINOR UNITS, server-computed
+  amountPaid    Int      @default(0)
+  amountDue     Int      @default(0)      // remainder collected at the door
+  transactionId String?  @db.ObjectId
+  expiresAt     DateTime?                 // reservation hold expiry
+  tickets       Ticket[]
+  @@index([eventId, status]) @@index([buyerUserId])
+}
+
+model Ticket {
+  id            String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  code          String   @unique          // opaque: DPIP-XXXX-XXXX
+  qrSecret      String                    // per-ticket HMAC secret (Phase 10)
+  status        String   @default("RESERVED") // RESERVED | PAID | CHECKED_IN | CANCELLED | REFUNDED | EXPIRED
+  eventId       String   @db.ObjectId
+  event         Event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  tierId        String   @db.ObjectId
+  tier          TicketTier @relation(fields: [tierId], references: [id])
+  orderId       String   @db.ObjectId
+  order         TicketOrder @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  holderUserId  String   @db.ObjectId
+  holder        User     @relation("TicketsHeld", fields: [holderUserId], references: [id], onDelete: Cascade)
+  amountPaid    Int      @default(0)      // minor units
+  amountDue     Int      @default(0)      // minor units
+  reservedUntil DateTime?
+  attendedAt    DateTime?
+  @@index([eventId, status]) @@index([holderUserId]) @@index([code])
+}
+```
+
+**Inverse fields this phase adds to Phase 8's models:** `Event.tiers TicketTier[]`,
+`Event.tickets Ticket[]`, `Event.orders TicketOrder[]`, `Event.ticketsEnabled Boolean @default(false)`,
+`Event.refundPolicy String?`, `Event.allowDoorDebt Boolean @default(false)`, and — critically —
+`Event.soldCount Int @default(0)` + `Event.capacity Int?` as the **event-wide** inventory counter.
+`User` gains `ticketOrders`, `ticketsHeld`.
+
+**Amount allocation rule (no ambiguity):** `bundlePrice` is the charged total per bundle;
+`orderSubtotal = quantity × bundlePrice`. Per-ticket allocation is
+`floor(bundlePrice / bundleSize)` with the remainder added to the first ticket, so
+`Σ ticket.amountPaid + Σ ticket.amountDue === order.subtotal` **exactly** (asserted in code, in
+integer minor units). Deposits are per issued ticket: `order.amountPaid = ticketCount ×
+depositPerTicket` for `RESERVE`, `order.subtotal` for `BUY`.
+
+## 9.2 Pricing rules (server-authoritative)
+
+`src/lib/services/ticketing/pricingService.ts`:
+
+- `resolveActiveTiers(event, now, viewer)` — a tier is purchasable when `active`, within
+  `[salesStartAt, salesEndAt)`, `sold + ticketsIssued <= capacity` (and the event has room), event
+  `PUBLISHED`, event not started (or `allowLateSales`), and (if `HIDDEN`) the supplied `accessCode`
+  matches.
+- **Early-bird / promo is just tiers with windows** — "10 DPIP until 1 Aug" is a tier with
+  `unitPrice: 1000, salesEndAt: 2026-08-01T00:00:00Z`; the next tier takes over automatically. No
+  discount-code engine, no coupon table. Organisers set N tiers with N windows.
+- **Bundles** are `bundleSize > 1` with a `bundlePrice` (e.g. 3 tickets for 25 DPIP).
+- `quote({ tierId, quantity, accessCode })` → `{ unitPrice, bundlePrice, ticketsIssued, subtotal,
+  depositTotal, dueAtDoor, currency }`, all minor units. The client only ever *displays* a quote;
+  checkout re-quotes server-side and ignores any client-sent amount.
+
+## 9.3 Checkout flows
+
+Everything below — inventory claim, ledger movement, order and ticket creation — happens inside
+**one** `prisma.$transaction`, so there is no window in which money moved without tickets or
+inventory was claimed without an order. The ledger call is the Phase 6 service running on the same
+`tx` handle.
+
+**Buy (full payment)**
+
+```
+POST /api/v1/events/:id/checkout { tierId, quantity, mode, accessCode, reference }
+  reference is REQUIRED and client-generated (uuid), so a retried request is provably the same order.
+
+  existing = order.findUnique({ reference }); if (existing) return existing     // before any claim
+  quote = pricingService.quote(...)                                            // server-authoritative
+
+  prisma.$transaction(tx => {
+    1. order = tx.ticketOrder.create({ reference, status: 'PENDING', ...quote })  // P2002 ⇒ replay
+    2. tier claim:  tx.ticketTier.updateMany({
+         where: { id: tierId, active: true, OR: [{ capacity: null },
+                  { sold: { lte: capacity - ticketsIssued } }] },
+         data: { sold: { increment: ticketsIssued } } })            // count !== 1 ⇒ SOLD_OUT
+    3. event claim: tx.event.updateMany({
+         where: { id: eventId, OR: [{ capacity: null },
+                  { soldCount: { lte: capacity - ticketsIssued } }] },
+         data: { soldCount: { increment: ticketsIssued } } })       // count !== 1 ⇒ EVENT_FULL
+    4. ledger.transfer(tx, { from: buyerDefaultWallet, to: SYSTEM:escrow,
+                             amountMinor: subtotal, kind: 'TICKET_PURCHASE', reference })
+    5. tx.ticket.createMany(ticketCount rows, allocation rule from §9.1)
+    6. tx.ticketOrder.update({ status: 'PAID' })
+  })
+```
+
+Any throw (sold out, event full, insufficient funds) aborts the whole thing: no leaked inventory,
+no orphaned debit, no partial order. Step 2's `capacity - ticketsIssued` is computed in the query
+builder from the tier's loaded `capacity`; the `OR: [{ capacity: null }]` branch handles unlimited
+tiers, which is why the naive `sold < capacity` form isn't used.
+
+**Reserve (deposit)**
+Identical, except step 4 moves only `ticketCount × depositPerTicket`
+(`kind: 'TICKET_RESERVATION'`), tickets are `RESERVED` with `amountDue` per the allocation rule and
+`reservedUntil = min(event.startsAt, now + holdWindow)`. The remainder is collected at the door in
+Phase 10 (`kind: 'TICKET_BALANCE'`).
+
+**Free / donation** tiers skip the transfer (donation runs a normal transfer of the chosen amount).
+
+**Escrow → organiser settlement**: funds sit in `SYSTEM:escrow` until
+`POST /api/v1/events/[eventId]/settle` (or the daily cron, 24 h after `endsAt`) transfers the net
+to the event wallet, then to the owner/org wallet. Cancellation refunds from escrow, which is why
+proceeds are not credited directly to the organiser.
+
+**Expiry cron** (`/api/cron/ticket-holds`, hourly): `RESERVED` orders past `expiresAt` that were
+never converted → `EXPIRED`, `tier.sold` and `event.soldCount` decremented in the same transaction,
+deposit refunded or forfeited per `event.refundPolicy` (default: refund before `startsAt`, forfeit
+after).
+
+## 9.4 API
+
+| Endpoint | Notes |
+|----------|-------|
+| `GET/POST /api/v1/events/[eventId]/tiers` · `PUT/DELETE .../tiers/[tierId]` | Organiser CRUD. A tier with issued tickets can't be deleted, only deactivated; price edits don't affect issued tickets. |
+| `POST /api/v1/events/[eventId]/quote` | `{ tierId, quantity, accessCode? }` → quote. |
+| `POST /api/v1/events/[eventId]/checkout` | `{ tierId, quantity, mode: 'BUY'\|'RESERVE', accessCode?, reference }` → `{ order, tickets }`. `reference` is required (client-generated uuid) and is the idempotency key for the entire checkout. |
+| `GET /api/v1/tickets?scope=mine\|event:<id>&cursor=` | Holder's wallet of tickets / organiser's manifest. |
+| `GET /api/v1/tickets/[ticketId]` | Holder or organiser; includes the rotating QR token (Phase 10). |
+| `POST /api/v1/tickets/[ticketId]/transfer` | `{ toUsername }` — gift a ticket (re-issues `qrSecret`, logs the transfer). |
+| `POST /api/v1/orders/[orderId]/cancel` | Refund per policy through the ledger. |
+| `POST /api/v1/events/[eventId]/settle` | Escrow → event wallet → owner wallet. |
+
+## 9.5 UI
+
+- Public event page action bar: **Buy** / **Reserve** buttons per tier with live availability,
+  countdown to the current window's `salesEndAt`, and the deposit split shown explicitly
+  ("Pay 4 DPIP now, 6 DPIP at the door").
+- `src/components/ticketCheckoutDialog.tsx` — quantity, quote, balance check with a link to top up,
+  confirm, success state with the ticket(s).
+- `src/components/ticketCard.tsx` + `src/app/[locale]/app/be/tickets/page.tsx` — the holder's ticket
+  wallet, with QR (Phase 10).
+- Manage console: tier editor (drag to sort, window pickers, bundle size, deposit), live sold/
+  capacity/revenue, manifest with export.
+
+## Migrations
+
+None required (all-new collections). `0029-enable-event-wallets.js` backfills an `EVENT` wallet for
+events created in Phase 8 before this phase shipped.
+
+## Verification
+
+- Two tiers with adjacent windows: before 1 Aug the quote is 10 DPIP; after, it's the next tier —
+  purely from the clock, no manual switch.
+- Bundle tier `bundleSize: 3, bundlePrice: 2500` issues 3 tickets, debits 25 DPIP, and the three
+  tickets' `amountPaid` sum to exactly 2500 minor units (remainder allocation asserted).
+- Reserve with a 4 DPIP per-ticket deposit on a 10 DPIP tier → wallet −4, ticket `RESERVED`,
+  `amountDue` 6.
+- Concurrency: 30 simultaneous buys against a 10-capacity tier → exactly 10 orders, `sold === 10`,
+  20 clean "sold out" errors, zero orphaned debits (assert the ledger sum is unchanged for the
+  failures).
+- Event-level cap: two tiers of 10 under an `Event.capacity` of 15 → the 16th ticket fails with
+  `EVENT_FULL`, and `soldCount === 15`.
+- Insufficient balance → no inventory leak (`sold` and `soldCount` unchanged).
+- Replayed `reference` → the same order, one debit, no extra tickets — including when the retry
+  arrives while the first request is still in flight.
+- Crash injected between the ledger transfer and ticket creation → nothing persisted; the buyer's
+  balance is intact and the seats are free.
+- Cancel before `startsAt` → refund lands, ticket `REFUNDED`, `sold`/`soldCount` decremented.
+- Hold expiry cron flips an unpaid reservation to `EXPIRED` and frees the seat.

--- a/docs/plans/phase-10-qr-attendance.md
+++ b/docs/plans/phase-10-qr-attendance.md
@@ -1,0 +1,156 @@
+# Phase 10 — QR attendance & door control
+
+**Goal:** a ticket holder shows a QR on their phone; a staff member scans it with theirs; the
+scanner sees who the person is, whether they may enter *this event, right now*, and how much they
+still owe; confirming stores an immutable attendance record visible to the holder and to the event
+manager.
+
+Depends on: Phase 9 (tickets), Phase 6 (ledger, for pay-at-door), Phase 8 (`EventStaff`).
+
+## 10.1 Threat model → token design
+
+A static QR encoding a ticket id can be screenshotted and forwarded. Therefore the QR is a
+**short-lived signed token**, not an identifier.
+
+```
+payload  = base64url(JSON{ v:1, t: ticketId, e: eventId, w: window })   // window = floor(epochSec/30)
+signature= HMAC-SHA256(payload, TICKET_QR_SECRET + ticket.qrSecret)     // server-side secret + per-ticket secret
+token    = "dpip1." + payload + "." + base64url(signature).slice(0,22)
+```
+
+- `window` rotates every **30 s**; the verifier accepts `window ∈ {n-1, n}` (one window of backward
+  skew tolerance, so a token lives at most ~60 s and never validates into the future).
+- The holder's ticket page re-derives a fresh token every 20 s while visible.
+- `TICKET_QR_SECRET` is server-only; `ticket.qrSecret` **and** the printed `code` are both
+  regenerated on ticket transfer, so a forwarded screenshot dies at the next window and a
+  transferred ticket invalidates every old credential.
+- Offline fallback: the ticket `code` (`DPIP-XXXX-XXXX`) can be typed into the scanner UI, which
+  takes the same verify path minus the token check (and is flagged `method: 'MANUAL'`).
+- **Honest limits**: rotation does not defeat a real-time relay (a confederate screen-sharing the
+  live QR). The mitigations are that check-in is single-use — the first scan wins and the second
+  gets `ALREADY_CHECKED_IN` with who and when — and that staff see the holder's photo and name on
+  the verdict card. Anything stronger needs identity checks at the door, which is a policy choice,
+  not a code change.
+- The 22-char (132-bit) truncated signature is not the weak point; rate limits exist to stop noise,
+  not to make forgery infeasible.
+
+Rate limits: verify is capped per scanner user (e.g. 120/min) and per ticket (10/min).
+
+## 10.2 Model
+
+```prisma
+model Attendance {
+  id             String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt      DateTime @default(now())
+  eventId        String   @db.ObjectId
+  event          Event    @relation("EventAttendances", fields: [eventId], references: [id], onDelete: Cascade)
+  ticketId       String   @unique @db.ObjectId     // one attendance per ticket
+  ticket         Ticket   @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  userId         String   @db.ObjectId             // the attendee
+  user           User     @relation("Attendances", fields: [userId], references: [id], onDelete: Cascade)
+  scannedByUserId String  @db.ObjectId
+  scannedBy      User     @relation("AttendanceScans", fields: [scannedByUserId], references: [id])
+  scannedAt      DateTime @default(now())
+  method         String   @default("QR")           // QR | MANUAL
+  amountCollected Int     @default(0)              // minor units
+  transactionId  String?  @db.ObjectId             // the TICKET_BALANCE payment, if any
+  location       Json?
+  deviceInfo     String?
+  @@index([eventId, scannedAt])
+  @@index([userId])
+}
+```
+
+**Inverse fields this phase adds:** `Event.attendances Attendance[] @relation("EventAttendances")`,
+`Ticket.attendance Attendance?`, `User.attendances Attendance[] @relation("Attendances")`,
+`User.attendanceScans Attendance[] @relation("AttendanceScans")`.
+
+`Ticket.status` moves to `CHECKED_IN` and `attendedAt` is set in the same operation.
+`@@unique` on `ticketId` is what makes double-scan impossible at the storage layer.
+
+## 10.3 API
+
+| Endpoint | Behaviour |
+|----------|-----------|
+| `GET /api/v1/tickets/[ticketId]/qr` | Holder only. Returns `{ token, expiresIn }`. Called on an interval by the ticket page. |
+| `POST /api/v1/scan/verify` | Staff only. `{ token \| code, eventId? }` → **read-only** decision payload (see below). Never mutates. |
+| `POST /api/v1/scan/confirm` | Staff only. `{ token \| code, collectAmount?, eventId }`. **Re-runs the full verify** — the earlier verify call authorizes nothing. Then, in one `prisma.$transaction`: CAS the ticket (`updateMany where { id, status: { in: ['PAID','RESERVED'] } } → CHECKED_IN`), collect `amountDue` via `ledgerService.transfer(kind: 'TICKET_BALANCE')` if owed, create `Attendance`. Idempotent by construction: the payment reference is **derived**, `ticket-balance:<ticketId>`, and `Attendance.ticketId` is unique — a repeat returns the existing attendance with `alreadyCheckedIn: true` and charges nothing. |
+| `GET /api/v1/events/[eventId]/attendance?cursor=` | Organiser manifest: who's in, when, by whom, collected totals; CSV export. |
+| `GET /api/v1/user/attendances` | The holder's own attendance history. |
+
+### Verify decision payload
+
+```jsonc
+{
+  "decision": "ALLOW" | "DENY" | "PAYMENT_DUE",
+  "reason": "OK" | "WRONG_EVENT" | "NOT_STARTED" | "ENDED" | "ALREADY_CHECKED_IN" |
+            "CANCELLED" | "REFUNDED" | "EXPIRED_RESERVATION" | "INVALID_TOKEN" | "EXPIRED_TOKEN",
+  "holder":   { "userId", "username", "displayName", "avatarUrl" },   // profile shown to the scanner
+  "event":    { "id", "name", "startsAt", "endsAt", "venueName", "isRunning": true },
+  "ticket":   { "id", "code", "tierName", "status", "amountPaid", "amountDue" },
+  "alreadyCheckedIn": { "at", "byDisplayName" } | null
+}
+```
+
+"Right to attend at this point in time" = the token's `eventId` matches the scanner's active event,
+the event is within its admission window
+(`doorsAt ?? startsAt − 2 h` … `endsAt ?? startsAt + 12 h`, computed in the event's `timezone`),
+and the ticket is `PAID` or `RESERVED`. A `RESERVED` ticket with `amountDue > 0` returns
+`PAYMENT_DUE` — the scanner UI then shows the amount and a "collect & admit" button, which is the
+marketing mechanic (cheap reservation, balance at the door).
+
+**Privacy:** the payload exposes only public profile fields — no email, no wallet balance, no
+purchase history.
+
+## 10.4 UI
+
+- **Holder** — `src/app/[locale]/app/be/tickets/[ticketId]/page.tsx`: big QR (`qrcode` npm →
+  canvas/SVG, no third-party rendering service), auto-refresh countdown, screen-brightness hint,
+  ticket code fallback, event summary, amount still due, add-to-calendar.
+- **Scanner** — `src/app/[locale]/app/be/events/[eventId]/door/page.tsx`:
+  `BarcodeDetector` when available, `@zxing/browser` fallback; camera permission flow; on decode →
+  `verify` → a full-screen green/amber/red verdict card with the holder's photo and name; amber
+  (`PAYMENT_DUE`) shows the amount and a confirm-collect action; manual code entry; a running
+  session tally (admitted / denied / collected).
+  **Offline behaviour: fail closed.** Both verify and confirm require the network; with no
+  connectivity the UI shows an explicit "offline — cannot admit" state. There is no offline queue:
+  optimistically admitting and reconciling later would let an expired, refunded or already-used
+  ticket through and could admit a `PAYMENT_DUE` holder without collecting. An offline mode would
+  need signed, pre-downloaded manifests and is deliberately out of scope.
+  The success state is only ever rendered **after** `confirm` returns 200.
+- Access: `EventStaff` role `SCANNER`/`MANAGER`, or the event owner, or MANAGER+ of the owning org.
+  The door page 403s otherwise.
+- `src/components/qrTicket.tsx`, `src/components/scanResultCard.tsx`.
+
+Deps to add: `qrcode` (generation), `@zxing/browser` (decode fallback).
+
+## 10.5 Manager visibility
+
+- Event manage console gains an **Attendance** tab: live count vs sold, arrival timeline, per-staff
+  scan counts, amounts collected at the door, no-shows, CSV export.
+- The holder's profile/dashboard shows attended events (subject to their own visibility settings).
+
+## Migrations
+
+None (new collection only).
+
+## Verification
+
+- Happy path: buy → open ticket → scan with a staff device → ALLOW → attendance stored, ticket
+  `CHECKED_IN`, manifest updates.
+- Re-scan the same ticket → `ALREADY_CHECKED_IN` with who/when, and **no** second `Attendance` row
+  and no second charge.
+- Screenshot a QR, wait 2 minutes, scan → `EXPIRED_TOKEN`.
+- Scan a valid ticket for event A at event B's door → `WRONG_EVENT`.
+- Scan 3 hours before doors → `NOT_STARTED`; after the window → `ENDED`.
+- Reserved ticket with 6 DPIP due → `PAYMENT_DUE`; collect → holder debited 6, ledger entries
+  written, attendance records `amountCollected: 600` (minor units); retrying the confirm collects
+  nothing extra (derived reference).
+- Two staff devices confirm the same ticket simultaneously → exactly one `Attendance`, exactly one
+  charge, the loser gets `alreadyCheckedIn`.
+- Kill the network after `verify` → the UI never shows admitted; `confirm` fails closed.
+- Insufficient balance at the door → clear error, no attendance, staff can still admit-with-debt
+  only if the organiser enabled it (`event.allowDoorDebt`, default off).
+- A non-staff user hitting `/scan/verify` → 403.
+- Transfer a ticket to another user → both the old QR **and** the old printed code fail; the new
+  holder's work.

--- a/docs/plans/phase-11-subscription-allowances.md
+++ b/docs/plans/phase-11-subscription-allowances.md
@@ -1,0 +1,176 @@
+# Phase 11 — Subscription DPIP allowances
+
+**Goal:** every paying subscriber's wallet is credited with their monthly DPIP allowance, exactly
+once per billing period, driven by a billing webhook and reconciled by a cron so a missed webhook
+never costs a user their tokens.
+
+Depends on: Phase 6 (ledger, default wallets, treasury).
+
+Today: plans live only in the Clerk dashboard, rendered by `<PricingTable for="user" />` in
+`src/views/pricing/pricingView.tsx`; entitlements are read at runtime with
+`useAuth().has({ feature })` in `useFeatureFlag`; there is **no** subscription record, no billing
+webhook, and one cron (`/api/cron/unread-chat-emails`, `CRON_SECRET` bearer auth).
+
+## 11.1 Plan catalog — `src/lib/billing/plans.ts`
+
+Code-side mirror keyed by the Clerk plan slug (the dashboard stays the source of truth for price
+and entitlements; this file is the source of truth for **DPIP allowance**):
+
+| Slug (Clerk) | Plan | Price/mo | DPIP/mo | Extras |
+|---|---|---|---|---|
+| `donator` | Dupip Donator (Starter) | $4.17 | **5** | AI Assistant, Lounge, Gallery |
+| `donator_plus` | Dupip Donator Plus | $8.34 | **10** | AI Assistant, Lounge, Gallery |
+| `donator_pro` | Dupip Donator Pro | $16.67 | **20** | + Virtual Numbers ×1, Coworking |
+| `donator_ultra` | Dupip Donator Ultra | $41.67 | **50** | + Virtual Numbers ×3, Coworking |
+| `donator_max` | Dupip Donator Max | $83.34 | **100** | + Virtual Numbers ×5, Coworking |
+
+```ts
+export const PLANS = {
+  donator:       { monthlyDpip: 5,   virtualNumbers: 0, features: ['ai_assistant','lounge','gallery'] },
+  donator_plus:  { monthlyDpip: 10,  virtualNumbers: 0, features: ['ai_assistant','lounge','gallery'] },
+  donator_pro:   { monthlyDpip: 20,  virtualNumbers: 1, features: ['ai_assistant','virtual_number','lounge','gallery','coworking'] },
+  donator_ultra: { monthlyDpip: 50,  virtualNumbers: 3, features: [...] },
+  donator_max:   { monthlyDpip: 100, virtualNumbers: 5, features: [...] },
+} as const
+```
+
+Unknown slug → `monthlyDpip: 0` + a loud server-side log (never guess an amount). The exact slugs
+must be read from the Clerk dashboard before implementation and asserted by a startup check.
+Marketing copy (access to lounges/galleries/studios/co-workings/residences "based on availability,
+consumes DPIP") stays in `src/locales/en.json` under `pricing.plans.*` — it is not duplicated here.
+
+## 11.2 Model
+
+```prisma
+model Subscription {
+  id                 String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+  userId             String   @db.ObjectId
+  user               User     @relation("Subscriptions", fields: [userId], references: [id], onDelete: Cascade)
+  provider           String   @default("CLERK")
+  externalId         String   @unique          // Clerk subscription (item) id
+  planSlug           String
+  status             String                    // ACTIVE | PAST_DUE | CANCELED | EXPIRED | TRIALING
+  monthlyDpipMinor   Int      @default(0)      // snapshot at write time, MINOR UNITS
+  currentPeriodStart DateTime?
+  currentPeriodEnd   DateTime?
+  cancelAtPeriodEnd  Boolean  @default(false)
+  raw                Json?                     // last provider payload, for forensics
+  grants             AllowanceGrant[]
+  @@index([userId, status]) @@index([status, currentPeriodEnd])
+}
+
+model AllowanceGrant {
+  id             String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt      DateTime @default(now())
+  subscriptionId String   @db.ObjectId
+  subscription   Subscription @relation(fields: [subscriptionId], references: [id], onDelete: Cascade)
+  userId         String   @db.ObjectId
+  walletId       String   @db.ObjectId
+  planSlug       String
+  periodKey      String                       // "2026-08" or the ISO date of currentPeriodStart
+  amount         Int                          // MINOR UNITS (Phase 6 convention)
+  transactionId  String   @db.ObjectId
+  source         String   @default("WEBHOOK") // WEBHOOK | CRON | MANUAL
+  @@unique([userId, periodKey, planSlug])     // one grant per plan per period
+  @@index([userId, periodKey])                // supports the per-period ceiling query
+  @@index([subscriptionId])
+}
+```
+
+Two guards, not one:
+
+1. `@@unique([userId, periodKey, planSlug])` makes "the same webhook twice" and "webhook *and*
+   cron" harmless — the second insert throws P2002 and the grant is skipped.
+2. A **per-period ceiling**: before granting, sum `AllowanceGrant.amount` for
+   `(userId, periodKey)` across *all* plan slugs. The grant is capped at
+   `max(0, targetPlan.monthlyDpip − alreadyGrantedThisPeriod)`. Without this, an
+   upgrade→downgrade→upgrade sequence inside one period could produce several plan-slug rows and
+   overgrant. The ceiling read and the grant run inside one `prisma.$transaction` so concurrent
+   plan-change events serialise.
+
+## 11.3 Grant service — `src/lib/services/billing/allowanceService.ts`
+
+```
+grantAllowance({ subscription, periodKey, source }):
+  1. plan = PLANS[subscription.planSlug]; if !plan or monthlyDpip === 0 → skip + log
+  2. wallet = getOrCreateDefaultWallet(subscription.userId)          // Phase 6
+  3. prisma.$transaction:
+       granted = Σ AllowanceGrant.amount where { userId, periodKey }   // all plan slugs
+       amount  = max(0, toMinor(plan.monthlyDpip) - granted)           // per-period ceiling
+       if (amount === 0) → done
+       reference = `allowance:${userId}:${periodKey}:${planSlug}`
+       ledgerService.credit(tx, { from: SYSTEM:treasury, to: wallet, amountMinor: amount,
+                                  kind: 'ALLOWANCE_GRANT', reference })
+       create AllowanceGrant                                          // P2002 ⇒ already granted
+```
+
+`periodKey(subscription)` = `currentPeriodStart` ISO date when the provider supplies it, else
+`YYYY-MM` of "now" — so a monthly plan gets exactly one grant per calendar month even when period
+data is missing.
+
+Proration/upgrades: the ceiling in step 3 *is* the proration policy — an upgrade mid-period tops up
+to the new plan's amount and never re-grants what was already issued. Downgrades grant nothing
+until the next period. Cancellation never claws back granted DPIP.
+
+## 11.4 Webhook — `POST /api/v1/webhooks/clerk-billing`
+
+- Svix signature verification, shared with the existing Clerk webhook helper.
+- Handles subscription lifecycle events (names verified against the Clerk dashboard at
+  implementation time — the handler switches on a normalised event family and **ignores unknown
+  types safely**): created / updated / active / past_due / canceled, plus item-level variants.
+- Maps payload → `Subscription` upsert on `externalId`; when the resulting status is active and the
+  period is new, calls `grantAllowance(source: 'WEBHOOK')`.
+- Always returns 200 for handled-or-ignored events; 4xx only for signature failures (so the
+  provider doesn't retry-storm on our bugs).
+- Every payload is stored in `Subscription.raw` for debugging drift.
+
+## 11.5 Cron — `/api/cron/dpip-allowances`
+
+Registered in `vercel.json` alongside the existing entry, daily at `0 6 * * *`,
+`Authorization: Bearer $CRON_SECRET` via the existing `isAuthorizedCronRequest`.
+
+Per run:
+1. Ensure every user has a default wallet (self-healing for pre-Phase-6 accounts).
+2. **Page Clerk's own subscription list**, not just our mirror — a subscription whose `created`
+   webhook was never delivered has no local row to reconcile, so a local-only scan would silently
+   never pay that user. Each Clerk subscription is upserted into `Subscription`, then, if
+   active and the period has no grant, `grantAllowance(source: 'CRON')` runs.
+3. Only mark a local subscription `EXPIRED` when **Clerk** reports it inactive/absent. Never expire
+   from local period dates alone — a missed renewal webhook would otherwise revoke a paying user.
+4. Emit a summary log (subscriptions seen, grants issued, total DPIP) for observability.
+
+`maxDuration = 300`, batched in pages of 200 with a cursor so it scales past one run's budget.
+
+## 11.6 UI
+
+- `src/views/pricing/pricingView.tsx` — each plan card gains its DPIP allowance line, sourced from
+  `PLANS` so the marketing copy and the code can't drift.
+- `src/components/walletBalanceCard.tsx` (Phase 6) shows "Next allowance: 20 DPIP on 1 Sep" from
+  the active subscription.
+- `/app/invest` gains a subscription panel: current plan, period, grant history (from
+  `AllowanceGrant` + statement entries), manage-subscription link to Clerk.
+
+## Migrations
+
+- `0030-backfill-subscriptions.js` — page through Clerk subscriptions, upsert `Subscription` rows.
+  **Grants no DPIP retroactively** (deliberate: back-crediting is a treasury decision, run manually
+  with `source: 'MANUAL'` if approved).
+
+## Verification
+
+- Simulate the webhook for a new `donator_pro` subscription → wallet +20 DPIP, one
+  `AllowanceGrant`, one `ALLOWANCE_GRANT` transaction with two ledger entries.
+- Re-deliver the identical webhook → no second credit, no error surfaced to Clerk.
+- **Never deliver the webhook at all** (subscription exists only in Clerk) → the cron discovers it
+  from Clerk's API, creates the mirror and grants once.
+- Delete the grant row's webhook path (simulate a missed event) then run the cron → granted once,
+  `source: 'CRON'`.
+- Run the cron twice in a row → the second run grants nothing.
+- Upgrade `donator` → `donator_pro` mid-period → +15 DPIP, not +20; then downgrade and upgrade
+  again in the same period → still a 20 DPIP total for that period (ceiling holds).
+- Cancel → no further grants after `currentPeriodEnd`, balance untouched; a locally "expired-looking"
+  but Clerk-active subscription is **not** expired by the cron.
+- A user with no wallet at all (legacy account) gets one created and credited.
+- Treasury balance decreases by exactly the sum of all grants issued.


### PR DESCRIPTION
# Consolidated Do + Be program plan (events, ticketing, DPIP)

Docs only. No code, schema, or dependency changes.

`docs/do-rebuild-plan.md` had Phases 1 and 2 already merged on this branch, and its remaining Phases 3 and 4 overlap heavily with the new Be module work (event listing and ticketing). Rather than plan Be separately and duplicate the storage, geolocation, ownership, and public-page groundwork, this consolidates everything into one roadmap under `docs/plans/`: an index plus one file per phase. The old plan gets a supersession banner and stays for its Phase 1-2 rationale.

## What the roadmap covers

| Phase | Scope |
|---|---|
| 03 | Do dry-out: date/ownership/social/public-page kits, kill remaining duplication (`getWeekNumber` x3, ad-hoc role checks in 5 routes, diverging like/comment entity lists) |
| 04 | Media, storage and geolocation foundation: iDrive e2 presigned uploads, client compression, EXIF, Google Places behind our own UI |
| 05 | Public list profiles and job board: public tasks as job posts, applications |
| 06 | DPIP off-chain ledger: integer minor units, transactional debit/credit, wallet at signup |
| 07 | Organizations: Clerk Orgs mirror, polymorphic `ownerType` on List/Wallet/Event |
| 08 | Events core: `Event` model, public event pages, RSVP, `/app/be/events` |
| 09 | Ticketing: tiers, promo/early-bird windows, bundles, deposits, escrow |
| 10 | QR attendance: rotating HMAC tokens, scanner API and door UI, attendance records |
| 11 | Subscription DPIP allowances: plan catalog, Clerk billing webhook plus reconciling cron |

Phases 3, 4 and 6 are independent and can run in parallel. Only 9 -> 10 is a hard chain.

## Design decisions worth a reviewer's attention

- **DPIP balances become an authoritative off-chain ledger** (confirmed with the user). Today balance is read live from Kaleido and `Transaction` rows sit at `pending` forever. The plan makes `Wallet.balance` plus double-entry `LedgerEntry` the source of truth, in **integer minor units** (Prisma-on-Mongo has no `Decimal`, and `Float` drifts under `$inc` and breaks `{ gte: amount }` guards). Kaleido becomes an optional mirror, off the critical path of a purchase.
- **Organizations mirror Clerk** (confirmed with the user). The `Organization` row *is* the org's public profile; an org cannot own a `Profile` because `Profile.userId` is required and unique.
- **The existing `Event` model is a life event**, referenced from tasks, notes, documents, `Day.eventIds` and `Comment.eventId`. Phase 8 renames it to `LifeEvent` with a full reference migration before reusing the `Event` name. This is the riskiest migration in the program.
- **Promo pricing is just tiers with sales windows**, no coupon engine. "10 DPIP until 1 Aug" is one tier with a `salesEndAt`.
- **Door check-in fails closed offline.** An earlier draft had an offline confirm queue; it was removed because it could admit refunded, already-used or unpaid holders.

## Review pass already applied

I ran the draft through a design review and folded in 13 corrections, notably: overselling across tiers (added an event-level `soldCount` claim alongside the tier claim), non-sparse nullable `@unique` slugs on MongoDB (slugs are now always generated), single-transaction checkout instead of compensating writes, derived payment references to prevent double-charge races at the door, cross-phase Prisma relation validity (inverse fields only land with both models), magic-byte verification for uploads plus an isolated media origin, and a subscription cron that reconciles against Clerk's own subscription list rather than only local mirrors.

## Screenshots/Videocasts/Preview Links

N/A - documentation only.

## Have you?

- [x] Reviewed your own PR?
- [x] Tested your own feature/fix meets Acceptance Criteria? (docs only; each phase file carries its own verification checklist for when it is implemented)
- [x] Made sure it passes all checks? (lint, build, integrations, scripts, etc)? (no code touched)
- [ ] Added screenshots? (if relevant)
- [ ] Added unit tests? (if necessary)
- [x] Added documentation? (if necessary)